### PR TITLE
add annotated tag support 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-
       - run: npm ci
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Bump version and push tag
-        uses: mathieudutour/github-tag-action@v2
+        uses: mathieudutour/github-tag-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -27,13 +27,14 @@ jobs:
 - **default_bump** _(optional)_ - Which type of bump to use when [none explicitly provided](#bumping) (default: `patch`).
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).
 - **release_branches** _(optional)_ - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`... (default: `master`).
+- **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 
 ### Outputs
 
 - **new_tag** - The value of the newly created tag. Note that if there hasn't been any new commit, this will be `undefined`.
 - **previous_tag** - The value of the previous tag (or `0.0.0` if none).
 
-> **_Note:_** This action creates a [lightweight tag](https://developer.github.com/v3/git/refs/#create-a-reference).
+> **_Note:_** This action creates a [lightweight tag](https://developer.github.com/v3/git/refs/#create-a-reference) by default.
 
 ### Bumping
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`..."
     required: false
     default: "master"
+  create_annotated_tag:
+    description: "Boolean to create an annotated tag rather than lightweight"
+    required: false
+    default: false
 runs:
   using: "node12"
   main: "lib/main.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-tag-action",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "A Github Action to automatically bump and tag master, on merge, with the latest SemVer formatted version.",
   "main": "lib/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,7 +115,7 @@ async function run() {
 
     const octokit = new GitHub(core.getInput("github_token"));
 
-    if (createAnnotatedTag) {
+    if (createAnnotatedTag === "true") {
       core.debug(`Creating annotated tag`);
 
       const tagCreateResponse = await octokit.git.createTag({

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ async function run() {
     const defaultBump = core.getInput("default_bump") as ReleaseType;
     const tagPrefix = core.getInput("tag_prefix");
     const releaseBranches = core.getInput("release_branches");
+    const createAnnotatedTag = core.getInput("create_annotated_tag");
 
     const { GITHUB_REF, GITHUB_SHA } = process.env;
 
@@ -114,6 +115,27 @@ async function run() {
 
     const octokit = new GitHub(core.getInput("github_token"));
 
+    if (createAnnotatedTag) {
+      core.debug(`Creating annotated tag`);
+
+      const tagCreateResponse = await octokit.git.createTag({
+        ...context.repo,
+        tag: newTag,
+        message: newTag,
+        object: GITHUB_SHA,
+        type: "commit"
+      });
+
+      core.debug(`Pushing annotated tag to the repo`);
+
+      await octokit.git.createRef({
+        ...context.repo,
+        ref: `refs/tags/${newTag}`,
+        sha: tagCreateResponse.data.sha
+      });
+      return;
+    }
+    
     core.debug(`Pushing new tag to the repo`);
 
     await octokit.git.createRef({


### PR DESCRIPTION
Hey @mathieudutour thanks for this action, my company wanted to use it with lerna (the `--since` option) and a get-latest-tag action but both of these work only with annotated tags.

If you're open to PRs I was able to get this "released" and working in my forked repo.

I also updated the README and package.json with the idea that you'd release it.