### PR TITLE
Fix #11: evaluation of dryRun as boolean

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -147,7 +147,7 @@ async function run() {
       return;
     }
 
-    if (dryRun) {
+    if ((/true/i).test(dryRun)) {
       core.info("Dry run: not performing tag action.");
       return;
     }


### PR DESCRIPTION
This one seems to work for me. Interestingly, the commit evaluation also seems to work now. Maybe my action build pulled in a new/current version of the dependency?
Fixes #11 