### PR TITLE
Always set previous_tag output

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -81,9 +81,11 @@ async function run() {
         )
       ).stdout.trim();
 
+      core.debug(`Setting previous_tag to: ${tag}`);
+      core.setOutput("previous_tag", tag);
+
       if (previousTagSha === GITHUB_SHA) {
         core.debug("No new commits since previous tag. Skipping...");
-        core.setOutput("previous_tag", tag);
         return;
       }
     } else {


### PR DESCRIPTION
# Always set output `previous_tag`

As of now the output `previous_tag` is set if no new commits were added or no tags are detected. I think that this output should be set always.

BTW. This is handy action. I am planning to use it a lot.