### PR TITLE
Add tag message for annotated tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ jobs:
 - **github_token** _(required)_ - Required for permission to tag the repo. Usually `${{ secrets.GITHUB_TOKEN }}`.
 - **default_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) (default: `patch`). You can also set `false` to avoid generating a new tag when none is explicitly provided.
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).
+- **tag_message** _(optional)_ - Set a custom tag message (only showed in annotated tags).
 - **release_branches** _(optional)_ - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`... (default: `master`).
 - **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 - **dry_run** _(optional)_ - Do not perform taging, just calculate next version and changelog, then exit

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
     description: "A prefix to the tag name (default: `v`)."
     required: false
     default: "v"
+  tag_message:
+    description: "Set a custom tag message (only showed in annotated tags)."
+    required: false
   release_branches:
     description: "Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`..."
     required: false


### PR DESCRIPTION
Custom tag message added. Which is shown with annotated tags.

I want to ask you to be critical of the update I did to parse the semver with regex. I did this because I got the null version before. However, I haven't delved into the dependencies used for semver.

Use case:
I (auto) deploy my Lambda functions with Terraform and would like to show the (version) ARN of the function in the tag.

I use different tag prefixes in the same repo, but different branches. Prefixes like 'alpha-v', 'beta-v' and 'v'. It does add up the versions but I have no problem with that. So I have tags with 'alpha-v0.0.1', 'alpha-v0.0.2', 'beta-v0.0.3', 'v0.0.4'. Maybe interesting to take a look at that.