### PR TITLE
Introduce 'custom_tag' input

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
 - **github_token** _(required)_ - Required for permission to tag the repo. Usually `${{ secrets.GITHUB_TOKEN }}`.
 - **default_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) (default: `patch`). You can also set `false` to avoid generating a new tag when none is explicitly provided.
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).
-- **custom_tag** _(optional)_ - Custom tag name. If specified, it overrides byump settings. 
+- **custom_tag** _(optional)_ - Custom tag name. If specified, it overrides bump settings. 
 - **release_branches** _(optional)_ - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`... (default: `master`).
 - **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 - **dry_run** _(optional)_ - Do not perform taging, just calculate next version and changelog, then exit

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ jobs:
 - **github_token** _(required)_ - Required for permission to tag the repo. Usually `${{ secrets.GITHUB_TOKEN }}`.
 - **default_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) (default: `patch`). You can also set `false` to avoid generating a new tag when none is explicitly provided.
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).
+- **custom_tag** _(optional)_ - Custom tag name. If specified, it overrides byump settings. 
 - **release_branches** _(optional)_ - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`... (default: `master`).
 - **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 - **dry_run** _(optional)_ - Do not perform taging, just calculate next version and changelog, then exit

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
     description: "A prefix to the tag name (default: `v`)."
     required: false
     default: "v"
+  custom_tag:
+    description: "Custom tag name. If specified, it overrides bump settings."
+    required: true
   release_branches:
     description: "Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`..."
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,7 @@ async function run() {
   try {
     const defaultBump = core.getInput("default_bump") as ReleaseType | "false";
     const tagPrefix = core.getInput("tag_prefix");
+    const customTag = core.getInput("custom_tag")
     const releaseBranches = core.getInput("release_branches");
     const createAnnotatedTag = core.getInput("create_annotated_tag");
     const dryRun = core.getInput("dry_run");
@@ -124,9 +125,14 @@ async function run() {
       return;
     }
 
-    const newVersion = `${inc(tag, bump || defaultBump)}${
-      preRelease ? `-${GITHUB_SHA.slice(0, 7)}` : ""
-    }`;
+    let newVersion = "";
+    if (!customTag) {
+      newVersion = `${inc(tag, bump || defaultBump)}${
+        preRelease ? `-${GITHUB_SHA.slice(0, 7)}` : ""
+      }`;
+    } else {
+      newVersion = customTag;
+    }
     const newTag = `${tagPrefix}${newVersion}`;
 
     core.setOutput("new_version", newVersion);


### PR DESCRIPTION
Fixes #28

In this PR, the input `custom_tag` is introduced to manually specify a tag, bypassing bump logic.
This PR takes inspiration from [laputansoft/github-tag-action](https://github.com/laputansoft/github-tag-action) fork that introduced a similar input, even though this PR tries to take as little as possible from that work, as it looks like it breaks bump logic.

There may be errors as it's the first time I edit a TypeScript file; in case, I'm sorry about that.