### PR TITLE
Fix issue when append_to_pre_release_tag is set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-tag-action",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-tag-action",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "description": "A GitHub Action to automatically bump and tag master, on merge, with the latest SemVer formatted version.",
   "main": "lib/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,11 +43,12 @@ async function run() {
       .some((branch) => currentBranch.match(branch));
     const isPrerelease = !isReleaseBranch && isPreReleaseBranch;
 
+    const identifier = appendToPreReleaseTag ? appendToPreReleaseTag : currentBranch;
     const validTags = await getValidTags();
     const latestTag = getLatestTag(validTags);
     const latestPrereleaseTag = getLatestPrereleaseTag(
       validTags,
-      appendToPreReleaseTag ? appendToPreReleaseTag : currentBranch
+      identifier
     );
 
     const commits = await getCommits(latestTag.commit.sha);
@@ -94,7 +95,7 @@ async function run() {
       const incrementedVersion = inc(
         previousTag,
         releaseType,
-        appendToPreReleaseTag ? appendToPreReleaseTag : currentBranch
+        identifier
       );
 
       if (!incrementedVersion) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ async function run() {
     const latestTag = getLatestTag(validTags);
     const latestPrereleaseTag = getLatestPrereleaseTag(
       validTags,
-      currentBranch
+      appendToPreReleaseTag ? appendToPreReleaseTag : currentBranch
     );
 
     const commits = await getCommits(latestTag.commit.sha);


### PR DESCRIPTION
When `append_to_pre_release_tag` is set it should be used as identifier to look up the latest pre-release tag.