### PR TITLE
#62 - commits analyzed repeatedly

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -11,6 +11,7 @@ import {
   mapCustomReleaseRules,
 } from './utils';
 import { createTag } from './github';
+import { Await } from './ts';
 
 export default async function main() {
   const defaultBump = core.getInput('default_bump') as ReleaseType | 'false';
@@ -63,11 +64,13 @@ export default async function main() {
     prefixRegex
   );
 
-  const commits = await getCommits(latestTag.commit.sha, GITHUB_SHA);
+  let commits: Await<ReturnType<typeof getCommits>>;
 
   let newVersion: string;
 
   if (customTag) {
+    commits = await getCommits(latestTag.commit.sha, GITHUB_SHA);
+
     newVersion = customTag;
   } else {
     let previousTag: ReturnType<typeof getLatestTag> | null;
@@ -100,6 +103,8 @@ export default async function main() {
     );
     core.setOutput('previous_version', previousVersion.version);
     core.setOutput('previous_tag', previousTag.name);
+
+    commits = await getCommits(previousTag.commit.sha, GITHUB_SHA);
 
     let bump = await analyzeCommits(
       { releaseRules: mappedReleaseRules },


### PR DESCRIPTION
This fix should contextualize commit analysis and calculate version bump based on the `previousTag` rather than `latestTag`.

Tests:
1. https://github.com/andres99x/submodule/actions/runs/596221476
Should analyze 1 commit and bump by a patch. ✅ 

2. https://github.com/andres99x/submodule/actions/runs/596225268
Should analyze 1 commit and bump by a minor. ✅ 

3. https://github.com/andres99x/submodule/actions/runs/596229746
Should analyze 1 commit and bump by a minor. ✅ 

4. https://github.com/andres99x/submodule/runs/1970663037
Should analyze 2 commit and bump by a minor. ✅  