### PR TITLE
fix: allow running the action on a PR

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -130,13 +130,7 @@ export default async function main() {
       ? `pre${bump || defaultBump}`
       : bump || defaultBump;
 
-    let incrementedVersion: string | null;
-
-    if (isPullRequest) {
-      incrementedVersion = inc(previousVersion, releaseType);
-    } else {
-      incrementedVersion = inc(previousVersion, releaseType, identifier);
-    }
+    const incrementedVersion = inc(previousVersion, releaseType, identifier);
 
     if (!incrementedVersion) {
       core.setFailed('Could not increment version.');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,6 +42,10 @@ export function getBranchFromRef(ref: string) {
   return ref.replace('refs/heads/', '');
 }
 
+export function isPr(ref: string) {
+  return ref.includes('refs/pull/');
+}
+
 export function getLatestTag(
   tags: Tags,
   prefixRegex: RegExp,

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -26,6 +26,23 @@ describe('utils', () => {
     expect(branch).toEqual('master');
   });
 
+  it('test if ref is PR', () => {
+    /*
+     * Given
+     */
+    const remoteRef = 'refs/pull/123/merge';
+
+    /*
+     * When
+     */
+    const isPullRequest = utils.isPr(remoteRef);
+
+    /*
+     * Then
+     */
+    expect(isPullRequest).toEqual(true);
+  });
+
   it('returns valid tags', async () => {
     /*
      * Given


### PR DESCRIPTION
This fixes #65 

I'm not a TypeScript developer, so please let me know what I can do to improve this.

My use case for this is mentioned in #65, but essentially I run this on a PR workflow against the default branch, in dry run mode so that I can ensure that the project version specified in a project file (.net csproj file in my case) is set appropriately by the developers.  It's one of a few pre-release checks that I want to enforce as we do automatic releases on merge to `main`.

Thanks!