### PR TITLE
feat: Add release_type to outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,8 @@ outputs:
     description: "Generated tag without the prefix"
   previous_tag:
     description: "Previous tag (or `0.0.0`)"
+  release_type:
+    description: "The computed release type (`major`, `minor`, `patch` or `custom` - can be prefixed with `pre`)"
   changelog:
     description: "The conventional changelog since the previous tag"
 inputs:

--- a/src/action.ts
+++ b/src/action.ts
@@ -74,6 +74,7 @@ export default async function main() {
   if (customTag) {
     commits = await getCommits(latestTag.commit.sha, GITHUB_SHA);
 
+    core.setOutput('release_type', 'custom');
     newVersion = customTag;
   } else {
     let previousTag: ReturnType<typeof getLatestTag> | null;
@@ -135,6 +136,7 @@ export default async function main() {
     const releaseType: ReleaseType = isPrerelease
       ? `pre${bump || defaultBump}`
       : bump || defaultBump;
+    core.setOutput('release_type', releaseType);
 
     const incrementedVersion = inc(previousVersion, releaseType, identifier);
 


### PR DESCRIPTION
This small pr. adds the computed `release_type` to `outputs`.

For custom tags I made it return `custom`, as I don't known what else would make more sense.