### PR TITLE
Paginate Tags for Repos with more that 100 tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-tag-action",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "private": true,
   "description": "A GitHub Action to automatically bump and tag master, on merge, with the latest SemVer formatted version.",
   "main": "lib/main.js",

--- a/src/action.ts
+++ b/src/action.ts
@@ -187,7 +187,7 @@ export default async function main() {
     return;
   }
 
-  if (validTags.map((tag) => tag.name).includes(newTag)) {
+  if (validTags.map((tag: any) => tag.name).includes(newTag)) {
     core.info('This tag already exists. Skipping the tag creation.');
     return;
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -13,15 +13,15 @@ export function getOctokitSingleton() {
   return octokitSingleton;
 }
 
-export async function listTags() {
+export async function listTags(): Promise<any> {
   const octokit = getOctokitSingleton();
 
-  const tags = await octokit.repos.listTags({
+  const tags = await octokit.paginate("GET /repos/{owner}/{repo}/tags", {
     ...context.repo,
     per_page: 100,
   });
 
-  return tags.data;
+  return tags;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,18 +12,18 @@ export async function getValidTags(prefixRegex: RegExp) {
   const tags = await listTags();
 
   const invalidTags = tags.filter(
-    (tag) => !valid(tag.name.replace(prefixRegex, ''))
+    (tag: { name: string; }) => !valid(tag.name.replace(prefixRegex, ''))
   );
 
-  invalidTags.forEach((name) => core.debug(`Found Invalid Tag: ${name}.`));
+  invalidTags.forEach((name: any) => core.debug(`Found Invalid Tag: ${name}.`));
 
   const validTags = tags
-    .filter((tag) => valid(tag.name.replace(prefixRegex, '')))
-    .sort((a, b) =>
+    .filter((tag: { name: string; }) => valid(tag.name.replace(prefixRegex, '')))
+    .sort((a: { name: string; }, b: { name: string; }) =>
       rcompare(a.name.replace(prefixRegex, ''), b.name.replace(prefixRegex, ''))
     );
 
-  validTags.forEach((tag) => core.debug(`Found Valid Tag: ${tag.name}.`));
+  validTags.forEach((tag: { name: any; }) => core.debug(`Found Valid Tag: ${tag.name}.`));
 
   return validTags;
 }
@@ -53,7 +53,7 @@ export function getLatestTag(
   tagPrefix: string
 ) {
   return (
-    tags.find((tag) => !prerelease(tag.name.replace(prefixRegex, ''))) || {
+    tags.find((tag: { name: string; }) => !prerelease(tag.name.replace(prefixRegex, ''))) || {
       name: `${tagPrefix}0.0.0`,
       commit: {
         sha: 'HEAD',
@@ -68,8 +68,8 @@ export function getLatestPrereleaseTag(
   prefixRegex: RegExp
 ) {
   return tags
-    .filter((tag) => prerelease(tag.name.replace(prefixRegex, '')))
-    .find((tag) => tag.name.replace(prefixRegex, '').match(identifier));
+    .filter((tag: { name: string; }) => prerelease(tag.name.replace(prefixRegex, '')))
+    .find((tag: { name: string; }) => tag.name.replace(prefixRegex, '').match(identifier));
 }
 
 export function mapCustomReleaseRules(customReleaseTypes: string) {


### PR DESCRIPTION
# What Am I?
Uses pagination to walk all tags for a repo for situations where there are more than 100 tags.

I have tested this on my own repos but those are unfortunately private so I cannot share directly.

But I have thrown the verbose output in this gist (note the 201 lines):
https://gist.github.com/ninjapanzer/c9e502fed0226c88e8ffd05b3e474194

# The Problem
We have multiple subprojects in the same repo and on each CD run we store an artifact as a release. We quickly exceeded 100 tags and as such some of our releases do not show up on the first page of the api call

This uses the @actions/github built in pagination support to walk the tags fore the entire repo so we can exceed the 100 tag window

# What changed
I changed the listTags abstraction to use the build in pagination tooling.

I encountered issues using the `.rest` abstraction like `octokit.rest.repos.listTags` as for some reason `rest` is undefined even though the plugin is available to the github client instance (Or it appears to be).

This changes the return type to any so I have added some type hints for any where appropriate.