### PR TITLE
Allow to pass a commit SHA instead using GITHUB_SHA.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ jobs:
 ### 📥 Inputs
 
 - **github_token** _(required)_ - Required for permission to tag the repo. Usually `${{ secrets.GITHUB_TOKEN }}`.
+- **commit_sha** _(optional)_ - Use this commit SHA instead GITHUB_SHA.
 
 #### Filter branches
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
 ### 📥 Inputs
 
 - **github_token** _(required)_ - Required for permission to tag the repo. Usually `${{ secrets.GITHUB_TOKEN }}`.
-- **commit_sha** _(optional)_ - Use this commit SHA instead GITHUB_SHA.
+- **commit_sha** _(optional)_ - The commit SHA value to add the tag. If specified, it uses this value instead GITHUB_SHA. It could be useful when a previous step merged a branch into github.ref.
 
 #### Fetch all tags
 

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
   pre_release_branches:
     description: "Comma separated list of branches (bash reg exp accepted) that will generate pre-release tags."
     required: false
+  commit_sha:
+    description: "Use this commit SHA instead GITHUB_SHA."
+    required: false
   create_annotated_tag:
     description: "Boolean to create an annotated tag rather than lightweight."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ inputs:
     description: "Comma separated list of branches (bash reg exp accepted) that will generate pre-release tags."
     required: false
   commit_sha:
-    description: "Use this commit SHA instead GITHUB_SHA."
+    description: "The commit SHA value to add the tag. If specified, it uses this value instead GITHUB_SHA. It could be useful when a previous step merged a branch into github.ref."
     required: false
   create_annotated_tag:
     description: "Boolean to create an annotated tag rather than lightweight."

--- a/src/action.ts
+++ b/src/action.ts
@@ -25,6 +25,7 @@ export default async function main() {
   const createAnnotatedTag = !!core.getInput('create_annotated_tag');
   const dryRun = core.getInput('dry_run');
   const customReleaseRules = core.getInput('custom_release_rules');
+  const commit_sha = core.getInput('commit_sha');
 
   let mappedReleaseRules;
   if (customReleaseRules) {
@@ -38,8 +39,9 @@ export default async function main() {
     return;
   }
 
-  if (!GITHUB_SHA) {
-    core.setFailed('Missing GITHUB_SHA.');
+  const commit_ref = commit_sha || GITHUB_SHA;
+  if (!commit_ref) {
+    core.setFailed('Missing commit_sha or GITHUB_SHA.');
     return;
   }
 
@@ -72,7 +74,7 @@ export default async function main() {
   let newVersion: string;
 
   if (customTag) {
-    commits = await getCommits(latestTag.commit.sha, GITHUB_SHA);
+    commits = await getCommits(latestTag.commit.sha, commit_ref);
 
     core.setOutput('release_type', 'custom');
     newVersion = customTag;
@@ -108,7 +110,7 @@ export default async function main() {
     core.setOutput('previous_version', previousVersion.version);
     core.setOutput('previous_tag', previousTag.name);
 
-    commits = await getCommits(previousTag.commit.sha, GITHUB_SHA);
+    commits = await getCommits(previousTag.commit.sha, commit_ref);
 
     let bump = await analyzeCommits(
       {
@@ -197,5 +199,5 @@ export default async function main() {
     return;
   }
 
-  await createTag(newTag, createAnnotatedTag, GITHUB_SHA);
+  await createTag(newTag, createAnnotatedTag, commit_ref);
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -29,7 +29,7 @@ export default async function main() {
   const dryRun = core.getInput('dry_run');
   const customReleaseRules = core.getInput('custom_release_rules');
   const shouldFetchAllTags = core.getInput('fetch_all_tags');
-  const commit_sha = core.getInput('commit_sha');
+  const commitSha = core.getInput('commit_sha');
 
   let mappedReleaseRules;
   if (customReleaseRules) {
@@ -43,8 +43,8 @@ export default async function main() {
     return;
   }
 
-  const commit_ref = commit_sha || GITHUB_SHA;
-  if (!commit_ref) {
+  const commitRef = commitSha || GITHUB_SHA;
+  if (!commitRef) {
     core.setFailed('Missing commit_sha or GITHUB_SHA.');
     return;
   }
@@ -81,7 +81,7 @@ export default async function main() {
   let newVersion: string;
 
   if (customTag) {
-    commits = await getCommits(latestTag.commit.sha, commit_ref);
+    commits = await getCommits(latestTag.commit.sha, commitRef);
 
     core.setOutput('release_type', 'custom');
     newVersion = customTag;
@@ -117,7 +117,7 @@ export default async function main() {
     core.setOutput('previous_version', previousVersion.version);
     core.setOutput('previous_tag', previousTag.name);
 
-    commits = await getCommits(previousTag.commit.sha, commit_ref);
+    commits = await getCommits(previousTag.commit.sha, commitRef);
 
     let bump = await analyzeCommits(
       {
@@ -224,5 +224,5 @@ export default async function main() {
     return;
   }
 
-  await createTag(newTag, createAnnotatedTag, commit_ref);
+  await createTag(newTag, createAnnotatedTag, commitRef);
 }


### PR DESCRIPTION
In some cases, when a previous step merged a branch into `github.ref` for example, I would like to specify the commit SHA to tag.