### PR TITLE
feat(tag fetching): support for more than a 100 tag at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ jobs:
 
 - **github_token** _(required)_ - Required for permission to tag the repo. Usually `${{ secrets.GITHUB_TOKEN }}`.
 
+#### Fetch all tags
+
+- **fetch_all_tags** _(optional)_ - By default, this action fetch the last 100 tags from Github. Sometimes, this is not enough and using this action will fetch all tags recursively (default: `false`).
+
 #### Filter branches
 
 - **release_branches** _(optional)_ - Comma separated list of branches (JavaScript regular expression accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any repository tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`... (default: `master,main`).

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: "Boolean to create an annotated tag rather than lightweight."
     required: false
     default: "false"
+  fetch_all_tags:
+    description: "Boolean to fetch all tags for a repo (if false, only the last 100 will be fetched)."
+    required: false
+    default: "false"
   dry_run:
     description: "Do not perform tagging, just calculate next version and changelog, then exit."
     required: false

--- a/src/action.ts
+++ b/src/action.ts
@@ -25,6 +25,7 @@ export default async function main() {
   const createAnnotatedTag = !!core.getInput('create_annotated_tag');
   const dryRun = core.getInput('dry_run');
   const customReleaseRules = core.getInput('custom_release_rules');
+  const shouldFetchAllTags = core.getInput('fetch_all_tags');
 
   let mappedReleaseRules;
   if (customReleaseRules) {
@@ -59,7 +60,10 @@ export default async function main() {
 
   const prefixRegex = new RegExp(`^${tagPrefix}`);
 
-  const validTags = await getValidTags(prefixRegex);
+  const validTags = await getValidTags(
+    prefixRegex,
+    /true/i.test(shouldFetchAllTags)
+  );
   const latestTag = getLatestTag(validTags, prefixRegex, tagPrefix);
   const latestPrereleaseTag = getLatestPrereleaseTag(
     validTags,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,8 +8,11 @@ import { Await } from './ts';
 
 type Tags = Await<ReturnType<typeof listTags>>;
 
-export async function getValidTags(prefixRegex: RegExp) {
-  const tags = await listTags();
+export async function getValidTags(
+  prefixRegex: RegExp,
+  shouldFetchAllTags: boolean
+) {
+  const tags = await listTags(shouldFetchAllTags);
 
   const invalidTags = tags.filter(
     (tag) => !valid(tag.name.replace(prefixRegex, ''))

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,0 +1,55 @@
+import { listTags } from '../src/github';
+
+jest.mock(
+  '@actions/github',
+  jest.fn().mockImplementation(() => ({
+    context: { repo: { owner: 'mock-owner', repo: 'mock-repo' } },
+    getOctokit: jest.fn().mockReturnValue({
+      repos: {
+        listTags: jest.fn().mockImplementation(({ page }: { page: number }) => {
+          if (page === 6) {
+            return { data: [] };
+          }
+
+          const res = [...new Array(100).keys()].map((_) => ({
+            name: `v0.0.${_ + (page - 1) * 100}`,
+            commit: { sha: 'string', url: 'string' },
+            zipball_url: 'string',
+            tarball_url: 'string',
+            node_id: 'string',
+          }));
+
+          return { data: res };
+        }),
+      },
+    }),
+  }))
+);
+
+describe('github', () => {
+  it('returns all tags', async () => {
+    const tags = await listTags(true);
+
+    expect(tags.length).toEqual(500);
+    expect(tags[499]).toEqual({
+      name: 'v0.0.499',
+      commit: { sha: 'string', url: 'string' },
+      zipball_url: 'string',
+      tarball_url: 'string',
+      node_id: 'string',
+    });
+  });
+
+  it('returns only the last 100 tags', async () => {
+    const tags = await listTags(true);
+
+    expect(tags.length).toEqual(500);
+    expect(tags[99]).toEqual({
+      name: 'v0.0.99',
+      commit: { sha: 'string', url: 'string' },
+      zipball_url: 'string',
+      tarball_url: 'string',
+      node_id: 'string',
+    });
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -71,7 +71,7 @@ describe('utils', () => {
     /*
      * When
      */
-    const validTags = await getValidTags(regex);
+    const validTags = await getValidTags(regex, false);
 
     /*
      * Then
@@ -121,7 +121,7 @@ describe('utils', () => {
     /*
      * When
      */
-    const validTags = await getValidTags(regex);
+    const validTags = await getValidTags(regex, false);
 
     /*
      * Then


### PR DESCRIPTION
Hi 👋 

This is a non-breaking PR which adds a new input parameter: `fetch_all_tags`.
By default, the behavior of the action stays the same: get the last 100 tags.
But turn this setting to true and it will fetch all tags from a repository recursively.

It may or may not come from a personal need (😏) that I think others could have too.

It's tested but let me know if I can do/clarify anything for you guys.

Best!

edit: Just saw [this](https://github.com/mathieudutour/github-tag-action/pull/84), let me know if you want me to close this or if you find it good enough to merge.

edit bis: One thing that this PR adds is configuration.
Testing pagination on a repo like eslint bring far slower results than fetching only the last 100 results so offering the choice might be a plus for some users.