### PR TITLE
Update outdated example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,10 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create a GitHub release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.tag_version.outputs.new_tag }}
-          release_name: Release ${{ steps.tag_version.outputs.new_tag }}
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
 ```
 


### PR DESCRIPTION
`actions/create-release` action in the example snippet has been archived and replaced by `ncipollo/release-action` as can be seen in [original action's readme](https://github.com/marketplace/actions/create-release#example) in the marketplace.
Also, since [the last release](https://github.com/ncipollo/release-action/releases/tag/v1.8.8) a `token` input is not required because a github token from `github` context is set as a default input value.