### PR TITLE
Support for incrementing the prerelease number when no automatic bumps are encountered.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ jobs:
 
 #### Customize the tag
 
-- **default_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) (default: `patch`). You can also set `false` to avoid generating a new tag when none is explicitly provided.
+- **default_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) when commiting to a release branch (default: `patch`). You can also set `false` to avoid generating a new tag when none is explicitly provided. Can be `patch, minor or major`.
+- **default_prerelease_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) when commiting to a prerelease branch (default: `prerelease`). You can also set `false` to avoid generating a new tag when none is explicitly provided. Can be `prerelease, prepatch, preminor or premajor`.
 - **custom_tag** _(optional)_ - Custom tag name. If specified, it overrides bump settings.
 - **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).

--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,13 @@ inputs:
     description: "Required for permission to tag the repo."
     required: true
   default_bump:
-    description: "Which type of bump to use when none explicitly provided (default: `patch`)."
+    description: "Which type of bump to use when none explicitly provided when commiting to a release branch (default: `patch`)."
     required: false
     default: "patch"
+  default_prerelease_bump:
+    description: "Which type of bump to use when none explicitly provided when commiting to a prerelease branch (default: `prerelease`)."
+    required: false
+    default: "prerelease"
   tag_prefix:
     description: "A prefix to the tag name (default: `v`)."
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "5.3.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",

--- a/src/action.ts
+++ b/src/action.ts
@@ -138,7 +138,7 @@ export default async function main() {
     }
 
     // If we have no bump, but want to support incrementing the prerelease number
-    if (!bump && defaultBump === 'prerelease') {
+    if (isPrerelease && !bump && defaultBump === 'prerelease') {
       bump = 'release';
     }
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -17,6 +17,7 @@ import { Await } from './ts';
 
 export default async function main() {
   const defaultBump = core.getInput('default_bump') as ReleaseType | 'false';
+  const defaultPreReleaseBump = core.getInput('default_prerelease_bump') as ReleaseType | 'false';
   const tagPrefix = core.getInput('tag_prefix');
   const customTag = core.getInput('custom_tag');
   const releaseBranches = core.getInput('release_branches');
@@ -124,11 +125,29 @@ export default async function main() {
       { commits, logger: { log: console.info.bind(console) } }
     );
 
-    if (!bump && defaultBump === 'false') {
+    // Determine if we should continue with tag creation based on main vs prerelease branch
+    let shouldContinue = true;
+    if (isPrerelease) {
+      if (!bump && defaultPreReleaseBump === 'false') {
+        shouldContinue = false;
+      }
+    } else {
+      if (!bump && defaultBump === 'false') {
+        shouldContinue = false;
+      }
+    }
+
+    // Default bump is set to false and we did not find an automatic bump
+    if (!shouldContinue) {
       core.debug(
-        'No commit specifies the version bump. Skipping the tag creation.'
+          'No commit specifies the version bump. Skipping the tag creation.'
       );
       return;
+    }
+
+    // If we don't have an automatic bump for the prerelease, just set our bump as the default
+    if (isPrerelease && !bump) {
+      bump = defaultPreReleaseBump;
     }
 
     // If somebody uses custom release rules on a prerelease branch they might create a 'preprepatch' bump.
@@ -137,13 +156,8 @@ export default async function main() {
       bump = bump.replace(preReg, '');
     }
 
-    // If we have no bump, but want to support incrementing the prerelease number
-    if (isPrerelease && !bump && defaultBump === 'prerelease') {
-      bump = 'release';
-    }
-
     const releaseType: ReleaseType = isPrerelease
-      ? `pre${bump || defaultBump}`
+      ? `pre${bump}`
       : bump || defaultBump;
     core.setOutput('release_type', releaseType);
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -17,7 +17,9 @@ import { Await } from './ts';
 
 export default async function main() {
   const defaultBump = core.getInput('default_bump') as ReleaseType | 'false';
-  const defaultPreReleaseBump = core.getInput('default_prerelease_bump') as ReleaseType | 'false';
+  const defaultPreReleaseBump = core.getInput('default_prerelease_bump') as
+    | ReleaseType
+    | 'false';
   const tagPrefix = core.getInput('tag_prefix');
   const customTag = core.getInput('custom_tag');
   const releaseBranches = core.getInput('release_branches');
@@ -140,7 +142,7 @@ export default async function main() {
     // Default bump is set to false and we did not find an automatic bump
     if (!shouldContinue) {
       core.debug(
-          'No commit specifies the version bump. Skipping the tag creation.'
+        'No commit specifies the version bump. Skipping the tag creation.'
       );
       return;
     }

--- a/src/action.ts
+++ b/src/action.ts
@@ -137,6 +137,11 @@ export default async function main() {
       bump = bump.replace(preReg, '');
     }
 
+    // If we have no bump, but want to support incrementing the prerelease number
+    if (!bump && defaultBump === 'prerelease') {
+      bump = 'release';
+    }
+
     const releaseType: ReleaseType = isPrerelease
       ? `pre${bump || defaultBump}`
       : bump || defaultBump;

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -455,8 +455,8 @@ describe('github-tag-action', () => {
       setInput('default_prerelease_bump', 'false');
       const commits: any[] = [];
       jest
-          .spyOn(utils, 'getCommits')
-          .mockImplementation(async (sha) => commits);
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
 
       const validTags = [
         {
@@ -468,8 +468,8 @@ describe('github-tag-action', () => {
         },
       ];
       jest
-          .spyOn(utils, 'getValidTags')
-          .mockImplementation(async () => validTags);
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
 
       /*
        * When
@@ -490,8 +490,8 @@ describe('github-tag-action', () => {
       setInput('default_prerelease_bump', 'prerelease');
       const commits = [{ message: 'this is my first fix', hash: null }];
       jest
-          .spyOn(utils, 'getCommits')
-          .mockImplementation(async (sha) => commits);
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
 
       const validTags = [
         {
@@ -500,11 +500,11 @@ describe('github-tag-action', () => {
           zipball_url: '',
           tarball_url: 'string',
           node_id: 'string',
-        }
+        },
       ];
       jest
-          .spyOn(utils, 'getValidTags')
-          .mockImplementation(async () => validTags);
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
 
       /*
        * When
@@ -515,9 +515,9 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
-          'v1.2.4-prerelease.0',
-          expect.any(Boolean),
-          expect.any(String)
+        'v1.2.4-prerelease.0',
+        expect.any(Boolean),
+        expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
     });

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -448,6 +448,45 @@ describe('github-tag-action', () => {
       setInput('pre_release_branches', 'prerelease');
     });
 
+    it('does create prerelease tag', async () => {
+      /*
+       * Given
+       */
+      setInput('default_bump', 'prerelease');
+      const commits = [{ message: 'this is my first fix', hash: null }];
+      jest
+          .spyOn(utils, 'getCommits')
+          .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.4-prerelease.0',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+          .spyOn(utils, 'getValidTags')
+          .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+          'v1.2.4-prerelease.1',
+          expect.any(Boolean),
+          expect.any(String)
+      );
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
     it('does create prepatch tag', async () => {
       /*
        * Given

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -448,11 +448,46 @@ describe('github-tag-action', () => {
       setInput('pre_release_branches', 'prerelease');
     });
 
+    it('does not create tag without commits and default_bump set to false', async () => {
+      /*
+       * Given
+       */
+      setInput('default_prerelease_bump', 'false');
+      const commits: any[] = [];
+      jest
+          .spyOn(utils, 'getCommits')
+          .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+          .spyOn(utils, 'getValidTags')
+          .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).not.toBeCalled();
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
     it('does create prerelease tag', async () => {
       /*
        * Given
        */
-      setInput('default_bump', 'prerelease');
+      setInput('default_prerelease_bump', 'prerelease');
       const commits = [{ message: 'this is my first fix', hash: null }];
       jest
           .spyOn(utils, 'getCommits')
@@ -460,14 +495,7 @@ describe('github-tag-action', () => {
 
       const validTags = [
         {
-          name: 'v0.2.4-prerelease.0',
-          commit: { sha: '012345', url: '' },
-          zipball_url: '',
-          tarball_url: 'string',
-          node_id: 'string',
-        },
-        {
-          name: 'v0.2.3-prerelease.0',
+          name: 'v1.2.3',
           commit: { sha: '012345', url: '' },
           zipball_url: '',
           tarball_url: 'string',
@@ -487,7 +515,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
-          'v0.2.4-prerelease.1',
+          'v1.2.4-prerelease.0',
           expect.any(Boolean),
           expect.any(String)
       );

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -460,12 +460,19 @@ describe('github-tag-action', () => {
 
       const validTags = [
         {
-          name: 'v1.2.4-prerelease.0',
+          name: 'v0.2.4-prerelease.0',
           commit: { sha: '012345', url: '' },
           zipball_url: '',
           tarball_url: 'string',
           node_id: 'string',
         },
+        {
+          name: 'v0.2.3-prerelease.0',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        }
       ];
       jest
           .spyOn(utils, 'getValidTags')
@@ -480,7 +487,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
-          'v1.2.4-prerelease.1',
+          'v0.2.4-prerelease.1',
           expect.any(Boolean),
           expect.any(String)
       );


### PR DESCRIPTION
Currently the action will not auto-increment the prerelease number. If no automatic bump from the commit log is found, the patch number will be auto incremented when the commit falls in a prerelease branch. (Obviously if default bump is not set to false). This PR allows the default_bump variable to be set to 'prerelease' which will auto increment the prereleae number if no bump is found.