### PR TITLE
add ability to filter commits by scope when determining new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ jobs:
 
 - **dry_run** _(optional)_ - Do not perform tagging, just calculate next version and changelog, then exit
 
+#### Commit Scope Filtering
+
+- **scopes** _(optional)_ - Comma separated list of commit scopes that will be used to filter commits when determining the new version. If left blank, will consider all commits.
+
 ### 📤 Outputs
 
 - **new_tag** - The value of the newly calculated tag. Note that if there hasn't been any new commit, this will be `undefined`.
@@ -126,6 +130,9 @@ The default graphite width of 10mm is always used for performance reasons.
 </table>
 
 If no commit message contains any information, then **default_bump** will be used.
+
+## Tests
+To run tests locally you need to set the environment variables `GITHUB_SERVER_URL` and `GITHUB_REPOSITORY` - e.g. `https://github.com` and `repoOwner/repoName` respectively.
 
 ## Credits
 

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,9 @@ inputs:
     description: "Do not perform tagging, just calculate next version and changelog, then exit."
     required: false
     default: "false"
+  scopes:
+    description: "Comma separated list of commit scopes that will be used to filter commits when determining the new version. If left blank, will consider all commits."
+    required: false
 
 runs:
   using: "node12"

--- a/src/action.ts
+++ b/src/action.ts
@@ -6,6 +6,7 @@ import {
   getBranchFromRef,
   isPr,
   getCommits,
+  getScopedCommits,
   getLatestPrereleaseTag,
   getLatestTag,
   getValidTags,
@@ -30,6 +31,7 @@ export default async function main() {
   const customReleaseRules = core.getInput('custom_release_rules');
   const shouldFetchAllTags = core.getInput('fetch_all_tags');
   const commitSha = core.getInput('commit_sha');
+  const validScopes = core.getInput('scopes');
 
   let mappedReleaseRules;
   if (customReleaseRules) {
@@ -120,6 +122,10 @@ export default async function main() {
     core.setOutput('previous_tag', previousTag.name);
 
     commits = await getCommits(previousTag.commit.sha, commitRef);
+
+    if (validScopes) {
+      commits = await getScopedCommits(commits, validScopes.split(','));
+    }
 
     let bump = await analyzeCommits(
       {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,23 @@ export async function getCommits(
     }));
 }
 
+export async function getScopedCommits(
+  commits: Await<ReturnType<typeof getCommits>>,
+  scopes: string[]
+) {
+  return commits.filter((commit) => {
+    return scopes.some((scope) => {
+      let re = new RegExp(
+        '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\\(' +
+          scope +
+          '\\)\\: [\\w ]+',
+        'g'
+      );
+      return commit.message.match(re);
+    });
+  });
+}
+
 export function getBranchFromRef(ref: string) {
   return ref.replace('refs/heads/', '');
 }

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -873,4 +873,159 @@ describe('github-tag-action', () => {
       expect(mockSetFailed).not.toBeCalled();
     });
   });
+
+  describe('scoped commits', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      setInput('scopes', 'api');
+    });
+
+    it('does create patch tag only considering scoped commits', async () => {
+      /*
+       * Given
+       */
+      const commits = [
+        { message: 'fix: this is my first fix', hash: null },
+        { message: 'feat(web): a web feature', hash: null },
+        { message: 'docs(test): some test documentation', hash: null },
+        { message: 'fix(api): an api bug fix', hash: null },
+        {
+          message: `feat(web): an api bug fix
+
+                    BREAKING CHANGE: something has been removed`,
+          hash: null,
+        },
+      ];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v1.2.4',
+        expect.any(Boolean),
+        expect.any(String)
+      );
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does create minor tag only considering scoped commits', async () => {
+      /*
+       * Given
+       */
+      const commits = [
+        { message: 'fix: this is my first fix', hash: null },
+        { message: 'fix(web): a web feature', hash: null },
+        { message: 'docs(test): some test documentation', hash: null },
+        { message: 'feat(api): an api bug fix', hash: null },
+        {
+          message: `feat(web): an api bug fix
+
+                    BREAKING CHANGE: something has been removed`,
+          hash: null,
+        },
+      ];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v1.3.0',
+        expect.any(Boolean),
+        expect.any(String)
+      );
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does create major tag only considering scoped commits', async () => {
+      /*
+       * Given
+       */
+      const commits = [
+        { message: 'fix: this is my first fix', hash: null },
+        { message: 'feat(web): a web feature', hash: null },
+        { message: 'docs(test): some test documentation', hash: null },
+        { message: 'feat(web): a web feature', hash: null },
+        { message: 'feat(api): an api bug fix', hash: null },
+        {
+          message: `feat(api): a breaking api change
+
+                    BREAKING CHANGE: something has been removed`,
+          hash: null,
+        },
+      ];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v2.0.0',
+        expect.any(Boolean),
+        expect.any(String)
+      );
+      expect(mockSetFailed).not.toBeCalled();
+    });
+  });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -136,6 +136,39 @@ describe('utils', () => {
     });
   });
 
+  it('filters out commits that dont match the given scopes', async () => {
+    /**
+     * Given
+     */
+    const validScopes = 'api,tests,something-dash';
+    const allCommits = [
+      { message: 'fix(api): fix a bug', hash: null },
+      { message: 'fix(tests): fix some tests', hash: null },
+      { message: 'fix(test): fix a tests', hash: null },
+      { message: 'feat: add a feature', hash: null },
+      { message: 'feat(api): add a feature to the api', hash: null },
+      { message: 'feat(something-dash): a dash', hash: null },
+    ];
+
+    /**
+     * When
+     */
+    const result = await utils.getScopedCommits(
+      allCommits,
+      validScopes.split(',')
+    );
+
+    /**
+     * Then
+     */
+    expect(result).toEqual([
+      { message: 'fix(api): fix a bug', hash: null },
+      { message: 'fix(tests): fix some tests', hash: null },
+      { message: 'feat(api): add a feature to the api', hash: null },
+      { message: 'feat(something-dash): a dash', hash: null },
+    ]);
+  });
+
   describe('custom release types', () => {
     it('maps custom release types', () => {
       /*


### PR DESCRIPTION
adds a new input `scopes` which allows the ability to filter commits
between version bumps on multiple scopes in order to more finely control
the versioning in a monorepo