### PR TITLE
feat: add prefix match tag input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ jobs:
 - **custom_tag** _(optional)_ - Custom tag name. If specified, it overrides bump settings.
 - **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).
+- **prefix_match_tag** _(optional)_ - Enhance tag validity check: given tag mush MATCH with tag_prefix + SemVer notation. (default: `false`).
 - **append_to_pre_release_tag** _(optional)_ - A suffix to the pre-release tag name (default: `<branch>`).
 
 #### Customize the conventional commit messages & titles of changelog sections

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "A prefix to the tag name (default: `v`)."
     required: false
     default: "v"
+  prefix_match_tag:
+    description: "Enhance tag validity check: given tag mush MATCH with tag_prefix + SemVer notation."
+    required: false
+    default: "false"
   append_to_pre_release_tag:
     description: "A suffix to a pre-release tag name (default: `<branch>`)."
     required: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-tag-action",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "private": true,
   "description": "A GitHub Action to automatically bump and tag master, on merge, with the latest SemVer formatted version.",
   "main": "lib/main.js",

--- a/src/action.ts
+++ b/src/action.ts
@@ -21,6 +21,7 @@ export default async function main() {
     | ReleaseType
     | 'false';
   const tagPrefix = core.getInput('tag_prefix');
+  const prefixMatchTag = core.getInput('prefix_match_tag');
   const customTag = core.getInput('custom_tag');
   const releaseBranches = core.getInput('release_branches');
   const preReleaseBranches = core.getInput('pre_release_branches');
@@ -69,7 +70,8 @@ export default async function main() {
 
   const validTags = await getValidTags(
     prefixRegex,
-    /true/i.test(shouldFetchAllTags)
+    /true/i.test(shouldFetchAllTags),
+    /true/i.test(prefixMatchTag)
   );
   const latestTag = getLatestTag(validTags, prefixRegex, tagPrefix);
   const latestPrereleaseTag = getLatestPrereleaseTag(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,8 @@ type Tags = Await<ReturnType<typeof listTags>>;
 
 export async function getValidTags(
   prefixRegex: RegExp,
-  shouldFetchAllTags: boolean
+  shouldFetchAllTags: boolean,
+  prefixMatchTag: boolean = false
 ) {
   const tags = await listTags(shouldFetchAllTags);
 
@@ -20,8 +21,17 @@ export async function getValidTags(
 
   invalidTags.forEach((name) => core.debug(`Found Invalid Tag: ${name}.`));
 
+  let prefixRegexMatchSemver: RegExp = RegExp(
+    prefixRegex.toString().slice(1, -1) + '[0-9]+',
+    'g'
+  );
+
   const validTags = tags
-    .filter((tag) => valid(tag.name.replace(prefixRegex, '')))
+    .filter(
+      (tag) =>
+        valid(tag.name.replace(prefixRegex, '')) &&
+        (!prefixMatchTag || tag.name.match(prefixRegexMatchSemver))
+    )
     .sort((a, b) =>
       rcompare(a.name.replace(prefixRegex, ''), b.name.replace(prefixRegex, ''))
     );

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -80,6 +80,96 @@ describe('utils', () => {
     expect(validTags).toHaveLength(1);
   });
 
+  it('returns valid tags #2', async () => {
+    /*
+     * Given
+     */
+    const testTags = [
+      {
+        name: 'v1.0.0',
+        commit: { sha: 'string', url: 'string' },
+        zipball_url: 'string',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: '0.0.91',
+        commit: { sha: 'string', url: 'string' },
+        zipball_url: 'string',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+    ];
+    const mockListTags = jest
+      .spyOn(github, 'listTags')
+      .mockImplementation(async () => testTags);
+
+    const regex_2 = /^/;
+
+    /*
+     * When
+     */
+    const validTags = await getValidTags(regex_2, false, true);
+
+    /*
+     * Then
+     */
+    expect(mockListTags).toHaveBeenCalled();
+    expect(validTags).toHaveLength(1);
+    expect(validTags[0]).toEqual({
+      name: '0.0.91',
+      commit: { sha: 'string', url: 'string' },
+      zipball_url: 'string',
+      tarball_url: 'string',
+      node_id: 'string',
+    });
+  });
+
+  it('returns valid tags #3', async () => {
+    /*
+     * Given
+     */
+    const testTags = [
+      {
+        name: 'v1.0.0',
+        commit: { sha: 'string', url: 'string' },
+        zipball_url: 'string',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: '1.0.91',
+        commit: { sha: 'string', url: 'string' },
+        zipball_url: 'string',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+    ];
+    const mockListTags = jest
+      .spyOn(github, 'listTags')
+      .mockImplementation(async () => testTags);
+
+    const regex_2 = /^v/;
+
+    /*
+     * When
+     */
+    const validTags = await getValidTags(regex_2, false, true);
+
+    /*
+     * Then
+     */
+    expect(mockListTags).toHaveBeenCalled();
+    expect(validTags).toHaveLength(1);
+    expect(validTags[0]).toEqual({
+      name: 'v1.0.0',
+      commit: { sha: 'string', url: 'string' },
+      zipball_url: 'string',
+      tarball_url: 'string',
+      node_id: 'string',
+    });
+  });
+
   it('returns sorted tags', async () => {
     /*
      * Given


### PR DESCRIPTION
I have a special case: we are moving our legacy app to totally new architecture. 

The legacy app is tagged WITHOUT the `v` prefix, based ONLY on the `SemVer` notation. For example, latest tag is: `0.0.91`
The new app is tagged WITH the `v` prefix. For example, latest tag is: `v1.0.0`

I have upgrade my GitHub Action CI/CD to continue to support the both notation, relay on this, I can easily identify `old` and `new` tags/packages. In the futur, it will be easy to remove all old stuff without to check if current tag is `old` or `new` app.

Both stacks could have new version. 

---- 

## Context: currents tags on my git hub repo:
![image](https://user-images.githubusercontent.com/1082289/167575655-8d16820f-3ba3-4af7-9fea-a66e745d7554.png)

## Actual behavior
If I push something related to my old stack, I'm attending that the new tag will be `0.0.92`. With the version `6.0`, it was not the case, the latest tag used was `v1.0.0` (related to the new stack), so, new tag will be `1.0.1`
![image](https://user-images.githubusercontent.com/1082289/167576130-5503fefe-43d7-48d1-8a27-eac47ce05131.png)

## Attended & new behavior
I use the new option `prefix_match_tag` I introduce to informe the `github-tag-action` I want that all tags must `MATCH` with `tag_prefix` to be valide. Below, usage example:
```yaml
- name: Bump version and push tag
  uses: gmocquet/github-tag-action@v6.1.0
  with:
      github_token: ${{ secrets.BOT_PAT }}
      tag_prefix: ""
      release_branches: "main-v1"
      create_annotated_tag: true
      dry_run: true
      prefix_match_tag: true
```

Now, when I push something related to old stack, all tags prefixed by `v` are exclude, so, I have the attended behavior: new version is `0.0.92`
![image](https://user-images.githubusercontent.com/1082289/167577583-ce18f6f9-c41a-43a4-88db-9e9a6393dc51.png)
