### PR TITLE
Use `${{github.token}}` as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ jobs:
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:
@@ -30,7 +28,7 @@ jobs:
 
 ### 📥 Inputs
 
-- **github_token** _(required)_ - Required for permission to tag the repo. Usually `${{ secrets.GITHUB_TOKEN }}`.
+- **github_token** _(optional)_ - GitHub token for permission to tag the repo (default: `${{github.token}}`).
 - **commit_sha** _(optional)_ - The commit SHA value to add the tag. If specified, it uses this value instead GITHUB_SHA. It could be useful when a previous step merged a branch into github.ref.
 
 #### Fetch all tags

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,7 @@ outputs:
 inputs:
   github_token:
     description: "GitHub token for permission to tag the repo."
+    required: false
     default: ${{ github.token }}
   default_bump:
     description: "Which type of bump to use when none explicitly provided when commiting to a release branch (default: `patch`)."

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,8 @@ outputs:
     description: "The conventional changelog since the previous tag"
 inputs:
   github_token:
-    description: "Required for permission to tag the repo."
-    required: true
+    description: "GitHub token for permission to tag the repo."
+    default: ${{ github.token }}
   default_bump:
     description: "Which type of bump to use when none explicitly provided when commiting to a release branch (default: `patch`)."
     required: false


### PR DESCRIPTION
GitHub Actions can get a token via `github` context like `actions/checkout`. 
https://github.com/actions/checkout/blob/bf085276cecdb0cc76fbbe0687a5a0e786646936/action.yml

Users can get rid of `${{secrets.GITHUB_TOKENS}}`.
