### PR TITLE
fix: enable creation of versions with commit sha postfix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: npm ci
       - run: npm run test
       - run: npm run check

--- a/src/action.ts
+++ b/src/action.ts
@@ -38,10 +38,15 @@ export default async function main() {
     mappedReleaseRules = mapCustomReleaseRules(customReleaseRules);
   }
 
-  const { GITHUB_REF, GITHUB_SHA } = process.env;
+  const { GITHUB_REF, GITHUB_SHA, GITHUB_EVENT_NAME } = process.env;
 
   if (!GITHUB_REF) {
     core.setFailed('Missing GITHUB_REF.');
+    return;
+  }
+
+  if (!GITHUB_EVENT_NAME) {
+    core.setFailed('Missing GITHUB_EVENT_NAME');
     return;
   }
 
@@ -58,8 +63,9 @@ export default async function main() {
   const isPreReleaseBranch = preReleaseBranches
     .split(',')
     .some((branch) => currentBranch.match(branch));
-  const isPullRequest = isPr(GITHUB_REF);
-  const isPrerelease = !isReleaseBranch && !isPullRequest && isPreReleaseBranch;
+  const isPullRequest = isPr(GITHUB_EVENT_NAME);
+  const isPrerelease =
+    !isReleaseBranch && (isPullRequest || isPreReleaseBranch);
 
   // Sanitize identifier according to
   // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions

--- a/src/action.ts
+++ b/src/action.ts
@@ -5,12 +5,14 @@ import { generateNotes } from '@semantic-release/release-notes-generator';
 import {
   getBranchFromRef,
   isPr,
+  isPrereleaseBranch,
   getCommits,
   getLatestPrereleaseTag,
   getLatestTag,
   getValidTags,
   mapCustomReleaseRules,
   mergeWithDefaultChangelogRules,
+  getIdentifier,
 } from './utils';
 import { createTag } from './github';
 import { Await } from './ts';
@@ -60,18 +62,22 @@ export default async function main() {
   const isReleaseBranch = releaseBranches
     .split(',')
     .some((branch) => currentBranch.match(branch));
-  const isPreReleaseBranch = preReleaseBranches
-    .split(',')
-    .some((branch) => currentBranch.match(branch));
+  const isPreReleaseBranch = isPrereleaseBranch(
+    preReleaseBranches,
+    currentBranch
+  );
   const isPullRequest = isPr(GITHUB_EVENT_NAME);
-  const isPrerelease =
-    !isReleaseBranch && (isPullRequest || isPreReleaseBranch);
+  const isPrerelease = !isReleaseBranch && !isPullRequest && isPreReleaseBranch;
 
   // Sanitize identifier according to
   // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
-  const identifier = (
-    appendToPreReleaseTag ? appendToPreReleaseTag : currentBranch
-  ).replace(/[^a-zA-Z0-9-]/g, '-');
+  const identifier = getIdentifier(
+    appendToPreReleaseTag,
+    currentBranch,
+    isPullRequest,
+    isPrerelease,
+    commitRef
+  );
 
   const prefixRegex = new RegExp(`^${tagPrefix}`);
 
@@ -187,7 +193,11 @@ export default async function main() {
       return;
     }
 
-    newVersion = incrementedVersion;
+    if (isPullRequest) {
+      newVersion = `${incrementedVersion}-${identifier}`;
+    } else {
+      newVersion = incrementedVersion;
+    }
   }
 
   core.info(`New version is ${newVersion}.`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,8 +49,8 @@ export function getBranchFromRef(ref: string) {
   return ref.replace('refs/heads/', '');
 }
 
-export function isPr(ref: string) {
-  return ref.includes('refs/pull/');
+export function isPr(eventName: string) {
+  return eventName.includes('pull_request');
 }
 
 export function getLatestTag(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,6 +53,18 @@ export function isPr(eventName: string) {
   return eventName.includes('pull_request');
 }
 
+export function isPrereleaseBranch(
+  preReleaseBranches: string,
+  currentBranch: string
+) {
+  if (preReleaseBranches) {
+    return preReleaseBranches
+      .split(',')
+      .some((branch) => currentBranch.match(branch));
+  }
+  return false;
+}
+
 export function getLatestTag(
   tags: Tags,
   prefixRegex: RegExp,
@@ -138,4 +150,24 @@ export function mergeWithDefaultChangelogRules(
   );
 
   return Object.values(mergedRules).filter((rule) => !!rule.section);
+}
+
+export function getIdentifier(
+  appendToPreReleaseTag: string,
+  currentBranch: string,
+  isPullRequest: boolean,
+  isPrerelease: boolean,
+  commitRef: string
+): string {
+  // On prerelease: Sanitize identifier according to
+  // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
+  let identifier: string;
+  if (isPullRequest) {
+    // On pull request, use commit SHA for identifier
+    return commitRef.slice(0, 7).replace(/[^a-zA-Z0-9-]/g, '-');
+  }
+  identifier = (
+    appendToPreReleaseTag ? appendToPreReleaseTag : currentBranch
+  ).replace(/[^a-zA-Z0-9-]/g, '-');
+  return identifier;
 }

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -8,6 +8,7 @@ import {
   setCommitSha,
   setInput,
   setRepository,
+  setEventName,
 } from './helper.test';
 
 jest.spyOn(core, 'debug').mockImplementation(() => {});
@@ -33,6 +34,7 @@ describe('github-tag-action', () => {
     jest.clearAllMocks();
     setBranch('master');
     setCommitSha('79e0ea271c26aa152beef77c3275ff7b8f8d8274');
+    setEventName('push');
     loadDefaultInputs();
   });
 

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -28,12 +28,13 @@ const mockSetOutput = jest
   .mockImplementation(() => {});
 
 const mockSetFailed = jest.spyOn(core, 'setFailed');
+const commitSha = '79e0ea271c26aa152beef77c3275ff7b8f8d8274';
 
 describe('github-tag-action', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     setBranch('master');
-    setCommitSha('79e0ea271c26aa152beef77c3275ff7b8f8d8274');
+    setCommitSha(commitSha);
     setEventName('push');
     loadDefaultInputs();
   });
@@ -487,6 +488,7 @@ describe('github-tag-action', () => {
       /*
        * Then
        */
+
       expect(mockCreateTag).not.toBeCalled();
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -880,11 +882,11 @@ describe('github-tag-action', () => {
   describe('pull requests', () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      setBranch('branch-with-my-first-feature');
+      setBranch('branch-with-my-first-fix');
       setEventName('pull_request');
     });
 
-    it('does not create tag on pull request', async () => {
+    it('does create new version with commit sha suffix on pull request', async () => {
       /*
        * Given
        */
@@ -914,6 +916,10 @@ describe('github-tag-action', () => {
       /*
        * Then
        */
+      expect(mockSetOutput).toHaveBeenCalledWith(
+        'new_version',
+        `1.2.4-${commitSha.slice(0, 7)}`
+      );
       expect(mockCreateTag).not.toHaveBeenCalledWith();
       expect(mockSetFailed).not.toBeCalled();
     });

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -224,6 +224,7 @@ describe('github-tag-action', () => {
       jest.clearAllMocks();
       setBranch('release');
       setInput('release_branches', 'release');
+      setEventName('push');
     });
 
     it('does create patch tag', async () => {
@@ -872,6 +873,48 @@ describe('github-tag-action', () => {
        */
       expect(mockSetOutput).toHaveBeenCalledWith('new_version', '2.0.0');
       expect(mockCreateTag).not.toBeCalled();
+      expect(mockSetFailed).not.toBeCalled();
+    });
+  });
+
+  describe('pull requests', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      setBranch('branch-with-my-first-feature');
+      setEventName('pull_request');
+    });
+
+    it('does not create tag on pull request', async () => {
+      /*
+       * Given
+       */
+      const commits = [{ message: 'fix: this is my first fix', hash: null }];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).not.toHaveBeenCalledWith();
       expect(mockSetFailed).not.toBeCalled();
     });
   });

--- a/tests/helper.test.ts
+++ b/tests/helper.test.ts
@@ -18,6 +18,10 @@ export function setCommitSha(sha: string) {
   process.env['GITHUB_SHA'] = sha;
 }
 
+export function setEventName(eventName: string) {
+  process.env['GITHUB_EVENT_NAME'] = eventName;
+}
+
 export function setInput(key: string, value: string) {
   process.env[`INPUT_${key.toUpperCase()}`] = value;
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -27,16 +27,16 @@ describe('utils', () => {
     expect(branch).toEqual('master');
   });
 
-  it('test if ref is PR', () => {
+  it('test if triggering event is PR', () => {
     /*
      * Given
      */
-    const remoteRef = 'refs/pull/123/merge';
+    const eventName = 'pull_request';
 
     /*
      * When
      */
-    const isPullRequest = utils.isPr(remoteRef);
+    const isPullRequest = utils.isPr(eventName);
 
     /*
      * Then


### PR DESCRIPTION
**What**
These changes are intended to enable creation of new versions with commit hash as a postfix, without generating an associated tag. 

**How**
Identifying pull requests is done by using the GitHub Environment variable GITHUB_EVENT_NAME to identify when the action is triggered by a pull request, read more [here.](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables)  This event is used in the isPr function to identify pull requests. The following functionalities has also been refactored to functions in the utils.ts file:
- Getting identifier (getIdentifier): Uses the pull request event to make an identifier with the first seven characters of the commit hash on pull requests. On all other events it works as it did before
- Check if prerelease branch (isPrereleaseBranch): Uses the preReleaseBranches input to identify if the currentBranch is a prerelease branch. If no preReleaseBranch was given, it returns to false.

**Why**
I started experimenting with these changes after creating issue #150 where I noted that the current version of this action does not generate new versions with the commit hash suffix on pull requests targeted at main branch, as described in the [Filter branches section](https://github.com/mathieudutour/github-tag-action#filter-branches)  of the documentation. During this work I also noticed that some functionality could be refactored into functions for improved readability of the code. Using the environment variable for event name also seemed like a more stable way of identifying pull requests than what was previously in place.  

**NOTE:** This is pretty much a duplicate of [pull request 151](https://github.com/mathieudutour/github-tag-action/pull/151) which I will be closing. Going to take the master branch of my fork in a different direction but still wanted to keep these changes as an option for this repository.