### PR TITLE
getValidTags() should exclude tags that do not match the prefixRegex

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,13 +15,17 @@ export async function getValidTags(
   const tags = await listTags(shouldFetchAllTags);
 
   const invalidTags = tags.filter(
-    (tag) => !prefixRegex.test(tag.name) || !valid(tag.name.replace(prefixRegex, ''))
+    (tag) =>
+      !prefixRegex.test(tag.name) || !valid(tag.name.replace(prefixRegex, ''))
   );
 
   invalidTags.forEach((name) => core.debug(`Found Invalid Tag: ${name}.`));
 
   const validTags = tags
-    .filter((tag) => prefixRegex.test(tag.name) && valid(tag.name.replace(prefixRegex, '')))
+    .filter(
+      (tag) =>
+        prefixRegex.test(tag.name) && valid(tag.name.replace(prefixRegex, ''))
+    )
     .sort((a, b) =>
       rcompare(a.name.replace(prefixRegex, ''), b.name.replace(prefixRegex, ''))
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,13 +15,13 @@ export async function getValidTags(
   const tags = await listTags(shouldFetchAllTags);
 
   const invalidTags = tags.filter(
-    (tag) => !valid(tag.name.replace(prefixRegex, ''))
+    (tag) => !prefixRegex.test(tag.name) || !valid(tag.name.replace(prefixRegex, ''))
   );
 
   invalidTags.forEach((name) => core.debug(`Found Invalid Tag: ${name}.`));
 
   const validTags = tags
-    .filter((tag) => valid(tag.name.replace(prefixRegex, '')))
+    .filter((tag) => prefixRegex.test(tag.name) && valid(tag.name.replace(prefixRegex, '')))
     .sort((a, b) =>
       rcompare(a.name.replace(prefixRegex, ''), b.name.replace(prefixRegex, ''))
     );

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -57,7 +57,7 @@ describe('utils', () => {
         node_id: 'string',
       },
       {
-        name: '1.2.3',
+        name: 'v1.2.3',
         commit: { sha: 'string', url: 'string' },
         zipball_url: 'string',
         tarball_url: 'string',
@@ -86,28 +86,28 @@ describe('utils', () => {
      */
     const testTags = [
       {
-        name: '1.2.4-prerelease.1',
+        name: 'v1.2.4-prerelease.1',
         commit: { sha: 'string', url: 'string' },
         zipball_url: 'string',
         tarball_url: 'string',
         node_id: 'string',
       },
       {
-        name: '1.2.4-prerelease.2',
+        name: 'v1.2.4-prerelease.2',
         commit: { sha: 'string', url: 'string' },
         zipball_url: 'string',
         tarball_url: 'string',
         node_id: 'string',
       },
       {
-        name: '1.2.4-prerelease.0',
+        name: 'v1.2.4-prerelease.0',
         commit: { sha: 'string', url: 'string' },
         zipball_url: 'string',
         tarball_url: 'string',
         node_id: 'string',
       },
       {
-        name: '1.2.3',
+        name: 'v1.2.3',
         commit: { sha: 'string', url: 'string' },
         zipball_url: 'string',
         tarball_url: 'string',
@@ -128,7 +128,55 @@ describe('utils', () => {
      */
     expect(mockListTags).toHaveBeenCalled();
     expect(validTags[0]).toEqual({
-      name: '1.2.4-prerelease.2',
+      name: 'v1.2.4-prerelease.2',
+      commit: { sha: 'string', url: 'string' },
+      zipball_url: 'string',
+      tarball_url: 'string',
+      node_id: 'string',
+    });
+  });
+
+  it('returns only prefixed tags', async () => {
+    /*
+     * Given
+     */
+    const testTags = [
+      {
+        name: 'app2/5.0.0',
+        commit: { sha: 'string', url: 'string' },
+        zipball_url: 'string',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: '7.0.0',
+        commit: { sha: 'string', url: 'string' },
+        zipball_url: 'string',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: 'app1/3.0.0',
+        commit: { sha: 'string', url: 'string' },
+        zipball_url: 'string',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+    ];
+    const mockListTags = jest
+      .spyOn(github, 'listTags')
+      .mockImplementation(async () => testTags);
+    /*
+     * When
+     */
+    const validTags = await getValidTags(/^app1\//, false);
+    /*
+     * Then
+     */
+    expect(mockListTags).toHaveBeenCalled();
+    expect(validTags).toHaveLength(1);
+    expect(validTags[0]).toEqual({
+      name: 'app1/3.0.0',
       commit: { sha: 'string', url: 'string' },
       zipball_url: 'string',
       tarball_url: 'string',


### PR DESCRIPTION
A fix for this issue: https://github.com/mathieudutour/github-tag-action/issues/143

This does introduce a slight behavior change in that tags that probably should have been excluded before are now definitely excluded. I think this is the correct behavior and people shouldn't have been relying on the previous behavior where tags without the requested prefix were being considered valid tags, but it is a change.