### PR TITLE
feat: allow the creation of tags without pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ jobs:
     1. `hotfix:patch,pre-feat:preminor`,
     2. `bug:patch:Bug Fixes,chore:patch:Chores`
 
+#### Create a tag without pushing it
+- **push_tag** _(optional)_ - Push the tag to the remote. If false, tag is created but not pushed. (default: `true`)
+
 #### Debugging
 
 - **dry_run** _(optional)_ - Do not perform tagging, just calculate next version and changelog, then exit

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,10 @@ inputs:
     description: "Do not perform tagging, just calculate next version and changelog, then exit."
     required: false
     default: "false"
+  push_tag:
+    description: "Push the created tag to remote ref. If false, tag is created, but not pushed."
+    required: false
+    default: "true"
 
 runs:
   using: "node16"

--- a/src/action.ts
+++ b/src/action.ts
@@ -32,6 +32,7 @@ export default async function main() {
   const customReleaseRules = core.getInput('custom_release_rules');
   const shouldFetchAllTags = core.getInput('fetch_all_tags');
   const commitSha = core.getInput('commit_sha');
+  const pushTag = core.getBooleanInput('push_tag');
 
   let mappedReleaseRules;
   if (customReleaseRules) {
@@ -228,5 +229,5 @@ export default async function main() {
     return;
   }
 
-  await createTag(newTag, createAnnotatedTag, commitRef);
+  await createTag(newTag, createAnnotatedTag, commitRef, pushTag);
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -68,7 +68,8 @@ export async function compareCommits(baseRef: string, headRef: string) {
 export async function createTag(
   newTag: string,
   createAnnotatedTag: boolean,
-  GITHUB_SHA: string
+  GITHUB_SHA: string,
+  pushTag: boolean = true
 ) {
   const octokit = getOctokitSingleton();
   let annotatedTag:
@@ -85,10 +86,14 @@ export async function createTag(
     });
   }
 
-  core.debug(`Pushing new tag to the repo.`);
-  await octokit.git.createRef({
-    ...context.repo,
-    ref: `refs/tags/${newTag}`,
-    sha: annotatedTag ? annotatedTag.data.sha : GITHUB_SHA,
-  });
+  if (pushTag) {
+    core.debug(`Pushing new tag to the repo.`);
+    await octokit.git.createRef({
+      ...context.repo,
+      ref: `refs/tags/${newTag}`,
+      sha: annotatedTag ? annotatedTag.data.sha : GITHUB_SHA,
+    });
+  } else {
+    core.debug(`Tag was not pushed to remote`);
+  }
 }

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -62,7 +62,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v0.0.1',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -92,7 +93,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v0.0.1',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -169,7 +171,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v2.0.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -211,7 +214,38 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.3.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
+      );
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does create a tag, but does not push the tag', async () => {
+      /*
+       * Given
+       */
+      setInput('push_tag', 'false');
+      const commits: any[] = [];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags: any[] = [];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+      /*
+       * When
+       */
+      await action();
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v0.0.1',
+        expect.any(Boolean),
+        expect.any(String),
+        false
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -257,7 +291,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.2.4',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -297,7 +332,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.3.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -341,7 +377,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v2.0.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -395,7 +432,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v2.2.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -440,7 +478,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.3.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -522,7 +561,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.2.4-prerelease.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -560,7 +600,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.2.4-prerelease.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -600,7 +641,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.3.0-prerelease.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -644,7 +686,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v2.0.0-prerelease.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -701,7 +744,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v2.2.0-prerelease.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -746,7 +790,8 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.3.0-prerelease.0',
         expect.any(Boolean),
-        expect.any(String)
+        expect.any(String),
+        true
       );
       expect(mockSetFailed).not.toBeCalled();
     });


### PR DESCRIPTION
### Changes
 - Add an optional input into the action.yaml to allow users to create a tag without pushing.
   - Default value is true, set to false to not push the tag.
 - Update `createTag` with a boolean parameter to check if we need to push
   - async `createRef` moved into conditional check with additional debug log to indicate tag is not pushed.
 - Update `action` module to extract boolean input
   - Used `getBooleanInput` as opposed to `getInput` for better error handling from the actions core lib.
 - Updated existing unittests to verify `true` is default arg for `pushTag` param.
 - New unittest for the input set to false explicitly.
 - Update README with section on using the input.
 
### Reasoning
In some cases it might be useful for a user to create a tag based on the current versioning without pushing the tag. For example, in python's setuptools_scm or poetry-dynamic-versioning, a 'dev' or 'prerelease' tag is created by the versioning library based on the current tag. By default, these libraries create a subminor version release and do no commit parsing - only tags - so it's up to the user to bump a minor or major version in the tag.

In a pull_request workflow, before the merge to the default branch, this action could be used to create a local tag so the build process can create a dev version that reflects any api change in the pull request.

