### PR TITLE
feat: Provide force_bump and force_prerelease_bump options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ jobs:
 
 - **default_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) when commiting to a release branch (default: `patch`). You can also set `false` to avoid generating a new tag when none is explicitly provided. Can be `patch, minor or major`.
 - **default_prerelease_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) when commiting to a prerelease branch (default: `prerelease`). You can also set `false` to avoid generating a new tag when none is explicitly provided. Can be `prerelease, prepatch, preminor or premajor`.
+- **force_bump** _(optional)_ - If specified, it ignores the type of bump provided when committing to a release branch, as well as `default_bump`. You can also set `false` to avoid generating a new tag. Can be `patch, minor or major`.
+- **force_prerelease_bump** _(optional)_ - If specified, it ignores the type of bump provided when committing to a release branch, as well as `default_bump`. You can also set `false` to avoid generating a new tag. Can be `prerelease, prepatch, preminor or premajor`.
 - **custom_tag** _(optional)_ - Custom tag name. If specified, it overrides bump settings.
 - **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,16 @@ inputs:
     description: "Which type of bump to use when none explicitly provided when commiting to a release branch (default: `patch`)."
     required: false
     default: "patch"
+  force_bump:
+    description: "A release type. If specified, it ignores the type of bump provided when committing to a release branch, as well as default_bump"
+    required: false
   default_prerelease_bump:
     description: "Which type of bump to use when none explicitly provided when commiting to a prerelease branch (default: `prerelease`)."
     required: false
     default: "prerelease"
+  force_prerelease_bump:
+    description: "A release type. If specified, it ignores the type of bump provided when committing to a prerelease branch, as well as default_prerelease_bump"
+    required: false
   tag_prefix:
     description: "A prefix to the tag name (default: `v`)."
     required: false

--- a/src/action.ts
+++ b/src/action.ts
@@ -17,9 +17,14 @@ import { Await } from './ts';
 
 export default async function main() {
   const defaultBump = core.getInput('default_bump') as ReleaseType | 'false';
+  const forceBump = core.getInput('force_bump') as ReleaseType | 'false' | '';
   const defaultPreReleaseBump = core.getInput('default_prerelease_bump') as
     | ReleaseType
     | 'false';
+  const forcePreReleaseBump = core.getInput('force_prerelease_bump') as
+    | ReleaseType
+    | 'false'
+    | '';
   const tagPrefix = core.getInput('tag_prefix');
   const customTag = core.getInput('custom_tag');
   const releaseBranches = core.getInput('release_branches');
@@ -141,6 +146,14 @@ export default async function main() {
       if (!bump && defaultBump === 'false') {
         shouldContinue = false;
       }
+    }
+
+    // Determine if we should override the bump to a given `force` version
+    if (isPrerelease && forcePreReleaseBump !== '') {
+      bump = forcePreReleaseBump;
+    }
+    if (!isPrerelease && forceBump !== '') {
+      bump = forceBump;
     }
 
     // Default bump is set to false and we did not find an automatic bump

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -222,6 +222,7 @@ describe('github-tag-action', () => {
       jest.clearAllMocks();
       setBranch('release');
       setInput('release_branches', 'release');
+      setInput('force_bump', '');
     });
 
     it('does create patch tag', async () => {
@@ -296,6 +297,47 @@ describe('github-tag-action', () => {
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.3.0',
+        expect.any(Boolean),
+        expect.any(String)
+      );
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does create tag as specified by force_bump', async () => {
+      setInput('force_bump', 'patch');
+      /*
+       * Given
+       */
+      const commits = [
+        { message: 'feat: this is my first feature', hash: null },
+      ];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v1.2.4',
         expect.any(Boolean),
         expect.any(String)
       );
@@ -451,6 +493,7 @@ describe('github-tag-action', () => {
       jest.clearAllMocks();
       setBranch('prerelease');
       setInput('pre_release_branches', 'prerelease');
+      setInput('force_prerelease_bump', '');
     });
 
     it('does not create tag without commits and default_bump set to false', async () => {
@@ -485,6 +528,45 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).not.toBeCalled();
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does create tag with force_prerelease_bump', async () => {
+      /*
+       * Given
+       */
+      setInput('force_prerelease_bump', 'prerelease');
+      const commits = [{ message: 'this is my first fix', hash: null }];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v1.2.4-prerelease.0',
+        expect.any(Boolean),
+        expect.any(String)
+      );
       expect(mockSetFailed).not.toBeCalled();
     });
 


### PR DESCRIPTION
Thanks for this very useful GH action!

# Motivation

Github-tag-action is a very useful tool, but some users may prefer explicit version bumps over semantic commits.
This pull request introduces 2 new options for this workflow: `force_bump` and `force_prerelease_bump`.

# Checks

Tested in https://github.com/RomainEndelin/test-releases ([Release](https://github.com/RomainEndelin/test-releases/blob/main/.github/workflows/create-release.yml#L25), [Pre-release](https://github.com/RomainEndelin/test-releases/blob/main/.github/workflows/create-pre-release.yml#L22))