### PR TITLE
feat: support refs through commit_sha input

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -12,7 +12,7 @@ import {
   mapCustomReleaseRules,
   mergeWithDefaultChangelogRules,
 } from './utils';
-import { createTag } from './github';
+import { createTag, validatedCommitShaInput } from './github';
 import { Await } from './ts';
 
 export default async function main() {
@@ -45,11 +45,12 @@ export default async function main() {
     return;
   }
 
-  const commitRef = commitSha || GITHUB_SHA;
+  let commitRef = commitSha || GITHUB_SHA;
   if (!commitRef) {
     core.setFailed('Missing commit_sha or GITHUB_SHA.');
     return;
   }
+  commitRef = await validatedCommitShaInput(commitRef);
 
   const currentBranch = getBranchFromRef(GITHUB_REF);
   const isReleaseBranch = releaseBranches

--- a/src/github.ts
+++ b/src/github.ts
@@ -92,3 +92,24 @@ export async function createTag(
     sha: annotatedTag ? annotatedTag.data.sha : GITHUB_SHA,
   });
 }
+
+/**
+ * Validates that the commitSha is a valid commit sha or a valid ref.
+ * Returns the commit sha for the input.
+ *
+ * @param commitSha - commit sha or ref
+ */
+export async function validatedCommitShaInput(commitSha: string) {
+  const octokit = getOctokitSingleton();
+  try {
+    return (await octokit.git.getCommit({
+      ...context.repo,
+      commit_sha: commitSha
+    })).data.sha;
+  } catch (e) {
+    return (await octokit.git.getRef({
+      ...context.repo,
+      ref: commitSha,
+    })).data.object.sha;
+  }
+}

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -22,6 +22,10 @@ const mockCreateTag = jest
   .spyOn(github, 'createTag')
   .mockResolvedValue(undefined);
 
+jest
+  .spyOn(github, 'validatedCommitShaInput')
+  .mockImplementation(async (commitSha) => commitSha)
+
 const mockSetOutput = jest
   .spyOn(core, 'setOutput')
   .mockImplementation(() => {});


### PR DESCRIPTION
# Use case

I want to be able to run an action manually and specify the commit I want to tag. By default, I want to provide `heads/main` in my repository which should map to whatever the head commit is. `commit_sha` is pretty good as an override when I have a commit, but if I want the branch ref, it won't work. The error I get when I provided `main` is something like:
> ❗  ::error::Invalid request.%0A%0AAt least 40 characters are required; only 4 were supplied.

# Modifications

Similar to how many git porcelain commands accept any refs, including commit SHAs and branch refs, I wrote a validation method that will check that the commit SHA is valid, and resolve a branch ref to a SHA if it wasn't a valid SHA. This allows plumbing calls like `octokit.git.createTag()` to work because the object actually refers to a SHA in all these intended cases.

# Test

Locally, I wrote a quick and dirty test to call this method with my own repository configuration and access token. `main` doesn't work, but `heads/main` works just fine. The test looks something like
```ts
await expect(validatedCommitShaInput('heads/main')).resolves..toEqual(commitSha)
```