### PR TITLE
RFC: feat: Adding commit filtering by path

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -22,6 +22,7 @@ export default async function main() {
     | 'false';
   const tagPrefix = core.getInput('tag_prefix');
   const customTag = core.getInput('custom_tag');
+  const pathFilter = core.getInput('path_filter');
   const releaseBranches = core.getInput('release_branches');
   const preReleaseBranches = core.getInput('pre_release_branches');
   const appendToPreReleaseTag = core.getInput('append_to_pre_release_tag');
@@ -85,7 +86,7 @@ export default async function main() {
   let newVersion: string;
 
   if (customTag) {
-    commits = await getCommits(latestTag.commit.sha, commitRef);
+    commits = await getCommits(latestTag.commit.sha, commitRef, pathFilter);
 
     core.setOutput('release_type', 'custom');
     newVersion = customTag;
@@ -121,7 +122,7 @@ export default async function main() {
     core.setOutput('previous_version', previousVersion.version);
     core.setOutput('previous_tag', previousTag.name);
 
-    commits = await getCommits(previousTag.commit.sha, commitRef);
+    commits = await getCommits(previousTag.commit.sha, commitRef, pathFilter);
 
     let bump = await analyzeCommits(
       {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,12 +37,18 @@ export async function getValidTags(
 
 export async function getCommits(
   baseRef: string,
-  headRef: string
+  headRef: string,
+  targetPath?: string
 ): Promise<{ message: string; hash: string | null }[]> {
   const commits = await compareCommits(baseRef, headRef);
 
   return commits
     .filter((commit) => !!commit.commit.message)
+    .filter((commit) =>
+      !targetPath
+        ? true
+        : commit.files?.some((file) => file.filename?.includes(targetPath))
+    )
     .map((commit) => ({
       message: commit.commit.message,
       hash: commit.sha,

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -6,6 +6,7 @@ import { defaultChangelogRules } from '../src/defaults';
 
 jest.spyOn(core, 'debug').mockImplementation(() => {});
 jest.spyOn(core, 'warning').mockImplementation(() => {});
+jest.spyOn(github, 'compareCommits');
 
 const regex = /^v/;
 
@@ -296,6 +297,81 @@ describe('utils', () => {
        */
       expect(result).toContainEqual(mappedReleaseRules[0]);
       expect(result).not.toContainEqual(mappedReleaseRules[1]);
+    });
+  });
+
+  describe('getCommits', () => {
+    it('filters by targetPath if defined', async () => {
+      /**
+       * Given
+       */
+      const commits = [
+        {
+          commit: {
+            message: 'feat: change to frontend',
+          },
+          files: [{ filename: 'frontend/package.json' }],
+          sha: '1234',
+        },
+        {
+          commit: {
+            message: 'feat: change to backend',
+          },
+          files: [{ filename: 'backend/main.py' }],
+          sha: '4567',
+        },
+      ];
+      // @ts-ignore
+      jest.spyOn(github, 'compareCommits').mockResolvedValue(commits);
+
+      /**
+       * When
+       */
+      const result = await utils.getCommits('baseRef', 'headRef', 'frontend');
+
+      /**
+       * Then
+       */
+      expect(result).toEqual([
+        { message: 'feat: change to frontend', hash: '1234' },
+      ]);
+    });
+
+    it('does no path filtering if targetPath undefined', async () => {
+      /**
+       * Given
+       */
+      const commits = [
+        {
+          commit: {
+            message: 'feat: change to frontend',
+          },
+          files: [{ filename: 'frontend/package.json' }],
+          sha: '1234',
+        },
+        {
+          commit: {
+            message: 'feat: change to backend',
+          },
+          files: [{ filename: 'backend/main.py' }],
+          sha: '4567',
+        },
+      ];
+      // @ts-ignore
+      jest.spyOn(github, 'compareCommits').mockResolvedValue(commits);
+
+      /**
+       * When
+       */
+      const result = await utils.getCommits('baseRef', 'headRef');
+
+      /**
+       * Then
+       */
+      expect(result).toEqual([
+        { message: 'feat: change to frontend', hash: '1234' },
+        { message: 'feat: change to backend', hash: '4567' },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Problem
We use `github-tag-action` to generate semver versions and then release notes for a number of projects. We are also using it in a monorepo with 2 different apps and this is where we're running into issues. Because `github_tag_action` looks at all the commits since the last tag we end up with a bunch of unrelated changes being considered e.g. 

```
feat: Update frontend
feat: Add new python library 
```

Where ideally we'd only have one bump per app.

## Solution
This is quick illustrative PR to explain how I might use the `github-tag-action` with a mono repo. In this change I added a path based filter to the `getCommits` - it's not wired through to the config / params that mean people can use it but I wanted to share this approach early to get some feedback before going any further.

Thoughts, comments, criticisms welcome.
