### PR TITLE
Add `scopes` option to filter analysis/changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ jobs:
 - **release_branches** _(optional)_ - Comma separated list of branches (JavaScript regular expression accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any repository tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`... (default: `master,main`).
 - **pre_release_branches** _(optional)_ - Comma separated list of branches (JavaScript regular expression accepted) that will generate the pre-release tags.
 
+#### Filter commits
+
+- **scopes** _(optional)_ - Comma separated list of scopes (JavaScript regular expression accepted) to consider when tagging, and to include in the changelog. If this option is specified, then commits with scopes not matching this list will not be analyzed nor included in the changelog.
+
 #### Customize the tag
 
 - **default_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) when commiting to a release branch (default: `patch`). You can also set `false` to avoid generating a new tag when none is explicitly provided. Can be `patch, minor or major`.

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,9 @@ inputs:
   pre_release_branches:
     description: "Comma separated list of branches (bash reg exp accepted) that will generate pre-release tags."
     required: false
+  scopes:
+    description: "Comma separated list of scopes (bash reg exp accepted) to analyze and to include in the changelog."
+    required: false
   commit_sha:
     description: "The commit SHA value to add the tag. If specified, it uses this value instead GITHUB_SHA. It could be useful when a previous step merged a branch into github.ref."
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@semantic-release/commit-analyzer": "^8.0.1",
         "@semantic-release/release-notes-generator": "^9.0.1",
         "conventional-changelog-conventionalcommits": "^4.6.1",
+        "conventional-commits-parser": "^3.2.0",
         "semver": "^7.3.5"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/release-notes-generator": "^9.0.1",
     "conventional-changelog-conventionalcommits": "^4.6.1",
+    "conventional-commits-parser": "^3.2.0",
     "semver": "^7.3.5"
   },
   "devDependencies": {

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -215,6 +215,48 @@ describe('github-tag-action', () => {
       );
       expect(mockSetFailed).not.toBeCalled();
     });
+
+    it('does skip commits not included in scopes', async () => {
+      /*
+       * Given
+       */
+      setInput('scopes', 'yes');
+      const commits = [
+        { message: 'fix(YES): 1ne', hash: null },
+        { message: 'feat(NO): 2wo', hash: null },
+      ];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v1.2.4',
+        expect.any(Boolean),
+        expect.any(String)
+      );
+      expect(mockSetFailed).not.toBeCalled();
+    });
   });
 
   describe('release branches', () => {

--- a/tests/helper.test.ts
+++ b/tests/helper.test.ts
@@ -18,8 +18,12 @@ export function setCommitSha(sha: string) {
   process.env['GITHUB_SHA'] = sha;
 }
 
-export function setInput(key: string, value: string) {
-  process.env[`INPUT_${key.toUpperCase()}`] = value;
+export function setInput(key: string, value: string | undefined) {
+  if (value) {
+    process.env[`INPUT_${key.toUpperCase()}`] = value;
+  } else {
+    delete process.env[`INPUT_${key.toUpperCase()}`];
+  }
 }
 
 export function setInputs(map: { [key: string]: string }) {
@@ -34,12 +38,10 @@ export function loadDefaultInputs() {
   const actionJson = yaml.load(actionYaml) as {
     inputs: { [key: string]: { default?: string } };
   };
-  const defaultInputs = Object.keys(actionJson['inputs'])
-    .filter((key) => actionJson['inputs'][key].default)
-    .reduce(
-      (obj, key) => ({ ...obj, [key]: actionJson['inputs'][key].default }),
-      {}
-    );
+  const defaultInputs = Object.keys(actionJson['inputs']).reduce(
+    (obj, key) => ({ ...obj, [key]: actionJson['inputs'][key].default }),
+    {}
+  );
   setInputs(defaultInputs);
 }
 

--- a/types/semantic.d.ts
+++ b/types/semantic.d.ts
@@ -1,5 +1,9 @@
 /// <reference types="semver" />
 
+declare module 'conventional-commits-parser' {
+  export function sync(message: string): { scope?: string };
+}
+
 declare module '@semantic-release/commit-analyzer' {
   export function analyzeCommits(
     config: {


### PR DESCRIPTION
Add a `scopes` option to limit the commits that will be included in the analysis (to determine the bump type) and the changelog.

This option is especially useful in a monorepo which might release distinct applications at a different cadence, as it lets you filter your tagging/changelog so it is based on only one feature within the monorepo.