### PR TITLE
Update utils.ts - print tag invalid tag names

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ export async function getValidTags(
       !prefixRegex.test(tag.name) || !valid(tag.name.replace(prefixRegex, ''))
   );
 
-  invalidTags.forEach((name) => core.debug(`Found Invalid Tag: ${name}.`));
+  invalidTags.forEach((tag) => core.debug(`Found Invalid Tag: ${tag.name}.`));
 
   const validTags = tags
     .filter(


### PR DESCRIPTION
While debugging my action I was seeing a lot of:
`##[debug]Found Invalid Tag: [object Object].`
This should print out the name instead of the opaque object