### PR TITLE
Support updating existing tag ref

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
   custom_tag:
     description: "Custom tag name. If specified, it overrides bump settings."
     required: false
+  force_update:
+    description: "Updates the sha of a tag if it already exists"
+    required: false
+    default: "false"
   custom_release_rules:
     description: "Comma separated list of release rules. Format: `<keyword>:<release_type>`. Example: `hotfix:patch,pre-feat:preminor`."
     required: false

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,24 +2,16 @@ import * as core from '@actions/core';
 import { prerelease, rcompare, valid } from 'semver';
 // @ts-ignore
 import DEFAULT_RELEASE_TYPES from '@semantic-release/commit-analyzer/lib/default-release-types';
-import { compareCommits, listTags } from './github';
+import { compareCommits, Tags } from './github';
 import { defaultChangelogRules } from './defaults';
-import { Await } from './ts';
 
-type Tags = Await<ReturnType<typeof listTags>>;
-
-export async function getValidTags(
-  prefixRegex: RegExp,
-  shouldFetchAllTags: boolean
-) {
-  const tags = await listTags(shouldFetchAllTags);
-
+export async function getValidTags(tags: Tags, prefixRegex: RegExp) {
   const invalidTags = tags.filter(
     (tag) =>
       !prefixRegex.test(tag.name) || !valid(tag.name.replace(prefixRegex, ''))
   );
 
-  invalidTags.forEach((name) => core.debug(`Found Invalid Tag: ${name}.`));
+  invalidTags.forEach((tag) => core.debug(`Found Invalid Tag: ${tag.name}.`));
 
   const validTags = tags
     .filter(

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -3,6 +3,7 @@ import * as utils from '../src/utils';
 import * as github from '../src/github';
 import * as core from '@actions/core';
 import {
+  clearInputs,
   loadDefaultInputs,
   setBranch,
   setCommitSha,
@@ -33,6 +34,7 @@ describe('github-tag-action', () => {
     jest.clearAllMocks();
     setBranch('master');
     setCommitSha('79e0ea271c26aa152beef77c3275ff7b8f8d8274');
+    clearInputs();
     loadDefaultInputs();
   });
 
@@ -47,9 +49,7 @@ describe('github-tag-action', () => {
         .mockImplementation(async (sha) => commits);
 
       const validTags: any[] = [];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -62,6 +62,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v0.0.1',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -77,9 +78,7 @@ describe('github-tag-action', () => {
         .mockImplementation(async (sha) => commits);
 
       const validTags: any[] = [];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -92,6 +91,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v0.0.1',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -116,9 +116,7 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
       ];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -154,9 +152,7 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
       ];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -169,6 +165,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v2.0.0',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -196,9 +193,7 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
       ];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -211,6 +206,53 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.3.0',
         expect.any(Boolean),
+        false,
+        expect.any(String)
+      );
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does update existing tag when force enabled', async () => {
+      /*
+       * Given
+       */
+      setInput('force_update', 'true');
+      setInput('custom_tag', 'latest');
+      setInput('tag_prefix', '');
+      const commits = [
+        {
+          message: 'feat: some new feature on a pre-release branch',
+          hash: null,
+        },
+        { message: 'james: this should make a preminor', hash: null },
+      ];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'latest',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'latest',
+        expect.any(Boolean),
+        true,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -242,9 +284,7 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
       ];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -257,6 +297,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.2.4',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -282,9 +323,7 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
       ];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -297,6 +336,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.3.0',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -326,9 +366,7 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
       ];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -341,6 +379,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v2.0.0',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -380,9 +419,7 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
       ];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -395,6 +432,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v2.2.0',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -425,9 +463,7 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
       ];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -440,6 +476,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.3.0',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -522,6 +559,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.2.4-prerelease.0',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -560,6 +598,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.2.4-prerelease.0',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -600,6 +639,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.3.0-prerelease.0',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -644,6 +684,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v2.0.0-prerelease.0',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -701,6 +742,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v2.2.0-prerelease.0',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -746,6 +788,7 @@ describe('github-tag-action', () => {
       expect(mockCreateTag).toHaveBeenCalledWith(
         'v1.3.0-prerelease.0',
         expect.any(Boolean),
+        false,
         expect.any(String)
       );
       expect(mockSetFailed).not.toBeCalled();
@@ -778,9 +821,7 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
       ];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -815,9 +856,7 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
       ];
-      jest
-        .spyOn(utils, 'getValidTags')
-        .mockImplementation(async () => validTags);
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
 
       /*
        * When
@@ -856,6 +895,7 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
       ];
+      jest.spyOn(github, 'listTags').mockImplementation(async () => validTags);
       jest
         .spyOn(utils, 'getValidTags')
         .mockImplementation(async () => validTags);

--- a/tests/helper.test.ts
+++ b/tests/helper.test.ts
@@ -26,6 +26,12 @@ export function setInputs(map: { [key: string]: string }) {
   Object.keys(map).forEach((key) => setInput(key, map[key]));
 }
 
+export function clearInputs() {
+  Object.keys(process.env)
+    .filter((key) => key.startsWith('INPUT_'))
+    .forEach((key) => delete process.env[key]);
+}
+
 export function loadDefaultInputs() {
   const actionYaml = fs.readFileSync(
     path.join(process.cwd(), 'action.yml'),

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -64,19 +64,15 @@ describe('utils', () => {
         node_id: 'string',
       },
     ];
-    const mockListTags = jest
-      .spyOn(github, 'listTags')
-      .mockImplementation(async () => testTags);
 
     /*
      * When
      */
-    const validTags = await getValidTags(regex, false);
+    const validTags = await getValidTags(testTags, regex);
 
     /*
      * Then
      */
-    expect(mockListTags).toHaveBeenCalled();
     expect(validTags).toHaveLength(1);
   });
 
@@ -114,19 +110,15 @@ describe('utils', () => {
         node_id: 'string',
       },
     ];
-    const mockListTags = jest
-      .spyOn(github, 'listTags')
-      .mockImplementation(async () => testTags);
 
     /*
      * When
      */
-    const validTags = await getValidTags(regex, false);
+    const validTags = await getValidTags(testTags, regex);
 
     /*
      * Then
      */
-    expect(mockListTags).toHaveBeenCalled();
     expect(validTags[0]).toEqual({
       name: 'v1.2.4-prerelease.2',
       commit: { sha: 'string', url: 'string' },
@@ -163,17 +155,13 @@ describe('utils', () => {
         node_id: 'string',
       },
     ];
-    const mockListTags = jest
-      .spyOn(github, 'listTags')
-      .mockImplementation(async () => testTags);
     /*
      * When
      */
-    const validTags = await getValidTags(/^app1\//, false);
+    const validTags = await getValidTags(testTags, /^app1\//);
     /*
      * Then
      */
-    expect(mockListTags).toHaveBeenCalled();
     expect(validTags).toHaveLength(1);
     expect(validTags[0]).toEqual({
       name: 'app1/3.0.0',


### PR DESCRIPTION
fixes #116 

Adds `force_update` parameter, allowing for updating the ref of an existing tag.  Useful for moving tags, which some workflows prefer for managing tags that reflect latest prereleases or deployments.  

I, personally, had a use-case where I wanted nightly artifact snapshots of a project to be simply tagged as "latest".  This is to avoid polluting the tagging, and ease distribution.  The builds themselves already report the git sha so there's no need for more specific in the github releases.