### PR TITLE
feat: support commit-analyzer presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,15 @@ jobs:
 - **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).
 - **append_to_pre_release_tag** _(optional)_ - A suffix to the pre-release tag name (default: `<branch>`).
+- **commit_analyzer_preset** _(optional)_ - A supported `conventional-changelog` preset (default: `angular`). See ![list of supported values](https://github.com/semantic-release/commit-analyzer#options)
 
 #### Customize the conventional commit messages & titles of changelog sections
 
 - **custom_release_rules** _(optional)_ - Comma separated list of release rules.
 
-  __Format__: `<keyword>:<release_type>:<changelog_section>` where `<changelog_section>` is optional and will default to [Angular's conventions](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
+  __Format__: `<keyword>:<release_type>:<changelog_section>` where `<changelog_section>` is optional. The `<changelog_section>` will default to the convention associated with the selected `commit_analyzer_preset`. Two of the most common conventions:
+    * [Angular's conventions](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
+    * [ConventionalCommit's conventions](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits).
 
   __Examples__:
     1. `hotfix:patch,pre-feat:preminor`,

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ The action will parse the new commits since the last tag using the [semantic-rel
 
 semantic-release uses the commit messages to determine the type of changes in the codebase. Following formalized conventions for commit messages, semantic-release automatically determines the next [semantic version](https://semver.org) number.
 
-By default semantic-release uses [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).
+By default semantic-release uses [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines), but different conventions can be used via the `commit_analyzer_preset` option.
 
-Here is an example of the release type that will be done based on a commit messages:
+Here is an example of the release type that will be done based on a commit messages, using the default settings:
 
 <table>
 <tr>

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,10 @@ inputs:
     description: "Do not perform tagging, just calculate next version and changelog, then exit."
     required: false
     default: "false"
+  commit_analyzer_preset:
+    description: "The semantic-release commit-analyzer preset to use for parsing the commit list. Refer to this list of available options. https://github.com/semantic-release/commit-analyzer?tab=readme-ov-file#options"
+    required: false
+    default: "angular"
 
 runs:
   using: "node20"

--- a/src/action.ts
+++ b/src/action.ts
@@ -32,6 +32,7 @@ export default async function main() {
   const customReleaseRules = core.getInput('custom_release_rules');
   const shouldFetchAllTags = core.getInput('fetch_all_tags');
   const commitSha = core.getInput('commit_sha');
+  const commitAnalyzerPreset = core.getInput('commit_analyzer_preset');
 
   let mappedReleaseRules;
   if (customReleaseRules) {
@@ -125,9 +126,10 @@ export default async function main() {
 
     let bump = await analyzeCommits(
       {
+        preset: commitAnalyzerPreset,
         releaseRules: mappedReleaseRules
           ? // analyzeCommits doesn't appreciate rules with a section /shrug
-            mappedReleaseRules.map(({ section, ...rest }) => ({ ...rest }))
+          mappedReleaseRules.map(({ section, ...rest }) => ({ ...rest }))
           : undefined,
       },
       { commits, logger: { log: console.info.bind(console) } }

--- a/src/action.ts
+++ b/src/action.ts
@@ -129,7 +129,7 @@ export default async function main() {
         preset: commitAnalyzerPreset,
         releaseRules: mappedReleaseRules
           ? // analyzeCommits doesn't appreciate rules with a section /shrug
-          mappedReleaseRules.map(({ section, ...rest }) => ({ ...rest }))
+            mappedReleaseRules.map(({ section, ...rest }) => ({ ...rest }))
           : undefined,
       },
       { commits, logger: { log: console.info.bind(console) } }

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -10,9 +10,9 @@ import {
   setRepository,
 } from './helper.test';
 
-jest.spyOn(core, 'debug').mockImplementation(() => { });
-jest.spyOn(core, 'info').mockImplementation(() => { });
-jest.spyOn(console, 'info').mockImplementation(() => { });
+jest.spyOn(core, 'debug').mockImplementation(() => {});
+jest.spyOn(core, 'info').mockImplementation(() => {});
+jest.spyOn(console, 'info').mockImplementation(() => {});
 
 beforeAll(() => {
   setRepository('https://github.com', 'org/repo');
@@ -24,7 +24,7 @@ const mockCreateTag = jest
 
 const mockSetOutput = jest
   .spyOn(core, 'setOutput')
-  .mockImplementation(() => { });
+  .mockImplementation(() => {});
 
 const mockSetFailed = jest.spyOn(core, 'setFailed');
 

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -10,9 +10,9 @@ import {
   setRepository,
 } from './helper.test';
 
-jest.spyOn(core, 'debug').mockImplementation(() => {});
-jest.spyOn(core, 'info').mockImplementation(() => {});
-jest.spyOn(console, 'info').mockImplementation(() => {});
+jest.spyOn(core, 'debug').mockImplementation(() => { });
+jest.spyOn(core, 'info').mockImplementation(() => { });
+jest.spyOn(console, 'info').mockImplementation(() => { });
 
 beforeAll(() => {
   setRepository('https://github.com', 'org/repo');
@@ -24,7 +24,7 @@ const mockCreateTag = jest
 
 const mockSetOutput = jest
   .spyOn(core, 'setOutput')
-  .mockImplementation(() => {});
+  .mockImplementation(() => { });
 
 const mockSetFailed = jest.spyOn(core, 'setFailed');
 
@@ -310,6 +310,94 @@ describe('github-tag-action', () => {
         {
           message:
             'my commit message\nBREAKING CHANGE:\nthis is a breaking change',
+          hash: null,
+        },
+      ];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v2.0.0',
+        expect.any(Boolean),
+        expect.any(String)
+      );
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does not create major tag when using default preset and bang(!) is present on prefix', async () => {
+      /*
+       * Given
+       */
+      setInput('commit_analyzer_preset', '');
+      const commits = [
+        {
+          message: 'feat!: this is a breaking change',
+          hash: null,
+        },
+      ];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v1.2.4',
+        expect.any(Boolean),
+        expect.any(String)
+      );
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does create major tag when using conventionalcommits preset and bang(!) is present on prefix', async () => {
+      /*
+       * Given
+       */
+      setInput('commit_analyzer_preset', 'conventionalcommits');
+      const commits = [
+        {
+          message: 'feat!: this is a breaking change',
           hash: null,
         },
       ];


### PR DESCRIPTION
* `feat`: support different commit-analyzer presets

## purpose
* adding support for `conventionalcommits`

this doesn't preclude the other presets, but this is the one specifically that i am after

## caveats
* this does not support the `presetConfig` option, meaning we can only provide the most basic implementation. this is also the case for `angular`, which has been the default up to this point

[full list of supported presets](https://github.com/semantic-release/commit-analyzer?tab=readme-ov-file#options)

closes #226
closes #208 
closes #80 