### PR TITLE
Added option to respect branch filters for pull request triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ jobs:
 
 #### Filter branches
 
-- **release_branches** _(optional)_ - Comma separated list of branches (JavaScript regular expression accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any repository tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`... (default: `master,main`).
+- **release_branches** _(optional)_ - Comma separated list of branches (JavaScript regular expression accepted) that will generate the release tags. Other branches generate versions postfixed with the commit hash and do not generate any repository tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`... (default: `master,main`).
 - **pre_release_branches** _(optional)_ - Comma separated list of branches (JavaScript regular expression accepted) that will generate the pre-release tags.
+- **handle_pr_as_branch** _(optional)_ - Boolean to handle PR triggers as branches when 'true'. Effectively GITHUB_HEAD_REF will be used to determine branch instead of GITHUB_REF. (defaults: `false`).
 
 #### Customize the tag
 

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,10 @@ inputs:
     description: "Boolean to create an annotated tag rather than lightweight."
     required: false
     default: "false"
+  handle_pr_as_branch:
+    description: "Boolean to handle PR triggers as branches when 'true'. Effectively GITHUB_HEAD_REF will be used instead of GITHUB_REF."
+    required: false
+    default: "false"
   fetch_all_tags:
     description: "Boolean to fetch all tags for a repo (if false, only the last 100 will be fetched)."
     required: false

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -7,6 +7,7 @@ import {
   setBranch,
   setCommitSha,
   setInput,
+  setPrBranch,
   setRepository,
 } from './helper.test';
 
@@ -870,6 +871,203 @@ describe('github-tag-action', () => {
        */
       expect(mockSetOutput).toHaveBeenCalledWith('new_version', '2.0.0');
       expect(mockCreateTag).not.toBeCalled();
+      expect(mockSetFailed).not.toBeCalled();
+    });
+  });
+
+  describe('pull requests', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      setPrBranch('source-branch');
+    });
+
+    it('does only output tag for pull request without handle_pr_as_branch set', async () => {
+      /*
+       * Given
+       */
+      setInput('handle_pr_as_branch', 'false');
+      const commits = [{ message: 'fix: this is my first fix', hash: null }];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockSetOutput).toHaveBeenCalledWith('new_version', '1.2.4');
+      expect(mockCreateTag).not.toBeCalled();
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does only output tag for pull request from release branch without handle_pr_as_branch set', async () => {
+      /*
+       * Given
+       */
+      setInput('release_branches', 'source-branch');
+      setInput('handle_pr_as_branch', 'false');
+      const commits = [{ message: 'fix: this is my first fix', hash: null }];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockSetOutput).toHaveBeenCalledWith('new_version', '1.2.4');
+      expect(mockCreateTag).not.toBeCalled();
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does only output tag for pull request from prerelease branch without handle_pr_as_branch set', async () => {
+      /*
+       * Given
+       */
+      setInput('pre_release_branches', 'source-branch');
+      setInput('handle_pr_as_branch', 'false');
+      const commits = [{ message: 'fix: this is my first fix', hash: null }];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockSetOutput).toHaveBeenCalledWith('new_version', '1.2.4');
+      expect(mockCreateTag).not.toBeCalled();
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does create tag for pull request from release branch with handle_pr_as_branch set', async () => {
+      /*
+       * Given
+       */
+      setInput('release_branches', 'source-branch');
+      setInput('handle_pr_as_branch', 'true');
+      const commits = [{ message: 'fix: this is my first fix', hash: null }];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v1.2.4',
+        expect.any(Boolean),
+        expect.any(String)
+      );
+      expect(mockSetFailed).not.toBeCalled();
+    });
+
+    it('does create tag for pull request from prerelease branch with handle_pr_as_branch set', async () => {
+      /*
+       * Given
+       */
+      setInput('pre_release_branches', 'source-branch');
+      setInput('handle_pr_as_branch', 'true');
+      const commits = [{ message: 'fix: this is my first fix', hash: null }];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.3',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v1.2.4-source-branch.0',
+        expect.any(Boolean),
+        expect.any(String)
+      );
       expect(mockSetFailed).not.toBeCalled();
     });
   });

--- a/tests/helper.test.ts
+++ b/tests/helper.test.ts
@@ -14,6 +14,11 @@ export function setBranch(branch: string) {
   process.env['GITHUB_REF'] = `refs/heads/${branch}`;
 }
 
+export function setPrBranch(branch: string) {
+  process.env['GITHUB_REF'] = `refs/pull/1/merge`;
+  process.env['GITHUB_HEAD_REF'] = branch;
+}
+
 export function setCommitSha(sha: string) {
   process.env['GITHUB_SHA'] = sha;
 }


### PR DESCRIPTION
Added an option to handle the name of the branch for Pull Requests. This would primarily be used to allow prerelease tags to be generated from Pull Request triggers.

I've added the option with a default that respects the existing behaviour and is backwards compatible.

I've adjusted the README and added tests for both existing behaviour and new.

It fixes my own problem, and I believe it may at least in part fix #150.